### PR TITLE
HOTFIX: Change quality defaults from 1.0 to None

### DIFF
--- a/workers/ingestion_spine/db.py
+++ b/workers/ingestion_spine/db.py
@@ -234,8 +234,8 @@ class DatabaseClient:
             "join_key": race_data.get('join_key'),
             "raw": race_data.get('raw', {}),
             # Quality metadata
-            "parse_confidence": race_data.get('parse_confidence', 1.0),
-            "quality_score": race_data.get('quality_score', 1.0),
+            "parse_confidence": race_data.get('parse_confidence'),
+            "quality_score": race_data.get('quality_score'),
             "quality_flags": race_data.get('quality_flags', [])
         }
 
@@ -297,8 +297,8 @@ class DatabaseClient:
             "form_figures": runner_data.get('form_figures'),
             "raw": runner_data.get('raw', {}),
             # Quality metadata
-            "confidence": runner_data.get('confidence', 1.0),
-            "extraction_method": runner_data.get('extraction_method', 'table'),
+            "confidence": runner_data.get('confidence'),
+            "extraction_method": runner_data.get('extraction_method'),
             "quality_flags": runner_data.get('quality_flags', [])
         }
 


### PR DESCRIPTION
Defaulting to 1.0 makes unknown data look perfect and defeats the Truth Layer. None is honest: if we don't know quality, don't pretend.

Changes:
- parse_confidence: 1.0 → None
- quality_score: 1.0 → None
- confidence: 1.0 → None
- extraction_method: 'table' → None