### PR TITLE
feat(v13): complete cognitive loop with read-only critics and epistem…

### DIFF
--- a/src/v13/__init__.py
+++ b/src/v13/__init__.py
@@ -1,0 +1,39 @@
+"""
+VÉLØ V13 - Living Intelligence System
+
+Constitutional Layer:
+- Episodic memory with epistemic time separation (decisionTime vs createdAt)
+- Read-only critics (Leakage, Cognitive Bias, Feature Extractor, Decision)
+- Doctrine guards (no auto-apply, no silent mutation, no learning without audit)
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+Checkpoint: V13_COGNITIVE_LOOP_COMPLETE
+"""
+
+from . import critics
+from . import episodes
+from .doctrine import (
+    DOCTRINE_CRITIC_AUTHORITY,
+    DOCTRINE_EPISTEMIC_TIME,
+    DOCTRINE_FEATURE_FIREWALL,
+    DOCTRINE_NO_AUTO_APPLY,
+    DOCTRINE_READ_ONLY,
+    enforce_episode_bound,
+    enforce_read_only,
+)
+
+__version__ = "13.0.0"
+
+__all__ = [
+    "critics",
+    "episodes",
+    "DOCTRINE_CRITIC_AUTHORITY",
+    "DOCTRINE_EPISTEMIC_TIME",
+    "DOCTRINE_FEATURE_FIREWALL",
+    "DOCTRINE_NO_AUTO_APPLY",
+    "DOCTRINE_READ_ONLY",
+    "enforce_episode_bound",
+    "enforce_read_only",
+]

--- a/src/v13/critics/__init__.py
+++ b/src/v13/critics/__init__.py
@@ -1,0 +1,60 @@
+"""
+VÉLØ V13 - Critics Module
+
+All critics are read-only, episode-bound, and emit proposals only (no auto-apply).
+
+Cognitive Loop:
+    Features → Bias → Leakage → Decision rationale
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+"""
+
+from .cognitive_bias import (
+    BiasFinding,
+    BiasCritique,
+    BiasPatchProposal,
+    CognitiveBiasCritic,
+)
+from .decision_critic import (
+    DecisionFinding,
+    DecisionCritique,
+    DecisionPatchProposal,
+    DecisionCritic,
+)
+from .feature_extractor import (
+    FeatureFinding,
+    FeatureCritique,
+    FeaturePatchProposal,
+    FeatureExtractorCritic,
+)
+from .leakage_detector import (
+    LeakageFinding,
+    LeakageCritique,
+    LeakagePatchProposal,
+    LeakageDetectorCritic,
+)
+
+__all__ = [
+    # Cognitive Bias Critic
+    "BiasFinding",
+    "BiasCritique",
+    "BiasPatchProposal",
+    "CognitiveBiasCritic",
+    # Decision Critic
+    "DecisionFinding",
+    "DecisionCritique",
+    "DecisionPatchProposal",
+    "DecisionCritic",
+    # Feature Extractor Critic
+    "FeatureFinding",
+    "FeatureCritique",
+    "FeaturePatchProposal",
+    "FeatureExtractorCritic",
+    # Leakage Detector Critic
+    "LeakageFinding",
+    "LeakageCritique",
+    "LeakagePatchProposal",
+    "LeakageDetectorCritic",
+]

--- a/src/v13/critics/cognitive_bias.py
+++ b/src/v13/critics/cognitive_bias.py
@@ -1,0 +1,417 @@
+"""
+VÉLØ V13 - Cognitive Bias Critic
+
+Detects cognitive biases in decision-making without agency.
+
+Bias Types:
+- Anchoring bias (over-reliance on first information)
+- Confirmation bias (seeking confirming evidence)
+- Recency bias (over-weighting recent events)
+- Overconfidence (unjustified high confidence)
+- Herd mentality (following market consensus)
+- Gambler's fallacy (expecting pattern reversal)
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+Doctrine: DOCTRINE_CRITIC_AUTHORITY
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..doctrine import enforce_read_only, enforce_episode_bound
+from ..episodes.schema import Episode, EpisodeArtifact, ArtifactType
+
+
+@dataclass
+class BiasFinding:
+    """A single cognitive bias detection finding."""
+    bias_type: str  # ANCHORING, CONFIRMATION, RECENCY, etc.
+    description: str
+    evidence: dict[str, Any]  # Episode artifact citations
+    severity: str  # INFO, WARNING, CRITICAL
+
+
+@dataclass
+class BiasCritique:
+    """Result of cognitive bias critique."""
+    episode_id: str
+    findings: list[BiasFinding]
+    is_clean: bool
+    total_biases: int
+
+
+@dataclass
+class BiasPatchProposal:
+    """Proposed patch to mitigate bias."""
+    episode_id: str
+    bias_type: str
+    proposed_fix: str
+    rationale: str
+
+
+class CognitiveBiasCritic:
+    """
+    Read-only critic that detects cognitive biases.
+    
+    Doctrine:
+    - Read-only (no state mutation)
+    - Episode-bound (all findings cite artifacts)
+    - No auto-apply (emits proposals only)
+    - Post-hoc audit only
+    """
+    
+    @enforce_read_only
+    @enforce_episode_bound
+    def critique(
+        self,
+        episode: Episode,
+        artifacts: list[EpisodeArtifact],
+    ) -> BiasCritique:
+        """
+        Detect cognitive biases in episode artifacts.
+        
+        Args:
+            episode: Episode to critique
+            artifacts: All artifacts for this episode
+            
+        Returns:
+            BiasCritique with findings
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY
+        """
+        findings: list[BiasFinding] = []
+        
+        # Get PRE_STATE and INFERENCE artifacts
+        pre_state_artifact = next(
+            (a for a in artifacts if a.artifact_type == ArtifactType.PRE_STATE),
+            None
+        )
+        inference_artifact = next(
+            (a for a in artifacts if a.artifact_type == ArtifactType.INFERENCE),
+            None
+        )
+        
+        if not pre_state_artifact or not inference_artifact:
+            return BiasCritique(
+                episode_id=episode.id,
+                findings=[],
+                is_clean=True,
+                total_biases=0,
+            )
+        
+        pre_state = pre_state_artifact.payload
+        inference = inference_artifact.payload
+        
+        # Check for anchoring bias
+        findings.extend(self._detect_anchoring_bias(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for confirmation bias
+        findings.extend(self._detect_confirmation_bias(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for recency bias
+        findings.extend(self._detect_recency_bias(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for overconfidence
+        findings.extend(self._detect_overconfidence(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for herd mentality
+        findings.extend(self._detect_herd_mentality(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for gambler's fallacy
+        findings.extend(self._detect_gamblers_fallacy(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        return BiasCritique(
+            episode_id=episode.id,
+            findings=findings,
+            is_clean=len(findings) == 0,
+            total_biases=len(findings),
+        )
+    
+    def _detect_anchoring_bias(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[BiasFinding]:
+        """Detect over-reliance on first information (e.g., morning odds)."""
+        findings = []
+        
+        # Check if morning odds heavily influence final prediction
+        if "morning_odds" in pre_state and "predictions" in inference:
+            morning_odds = pre_state.get("morning_odds", {})
+            predictions = inference.get("predictions", [])
+            
+            # Check if top prediction matches morning favorite
+            if morning_odds and predictions:
+                morning_favorite = min(morning_odds.items(), key=lambda x: x[1])[0]
+                top_prediction = predictions[0].get("runner_name") if predictions else None
+                
+                if morning_favorite == top_prediction:
+                    findings.append(BiasFinding(
+                        bias_type="ANCHORING",
+                        description="Top prediction matches morning favorite (possible anchoring bias)",
+                        evidence={
+                            "pre_state_artifact_id": pre_state_artifact.id,
+                            "inference_artifact_id": inference_artifact.id,
+                            "morning_favorite": morning_favorite,
+                            "top_prediction": top_prediction,
+                        },
+                        severity="WARNING",
+                    ))
+        
+        return findings
+    
+    def _detect_confirmation_bias(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[BiasFinding]:
+        """Detect seeking confirming evidence."""
+        findings = []
+        
+        # Check if rationale only mentions supporting evidence
+        if "rationale" in inference:
+            rationale = inference["rationale"].lower()
+            
+            # Look for one-sided language
+            confirming_words = ["confirms", "supports", "validates", "proves"]
+            disconfirming_words = ["contradicts", "challenges", "questions", "opposes"]
+            
+            confirming_count = sum(1 for word in confirming_words if word in rationale)
+            disconfirming_count = sum(1 for word in disconfirming_words if word in rationale)
+            
+            if confirming_count > 0 and disconfirming_count == 0:
+                findings.append(BiasFinding(
+                    bias_type="CONFIRMATION",
+                    description="Rationale only mentions confirming evidence (possible confirmation bias)",
+                    evidence={
+                        "inference_artifact_id": inference_artifact.id,
+                        "confirming_count": confirming_count,
+                        "disconfirming_count": disconfirming_count,
+                    },
+                    severity="INFO",
+                ))
+        
+        return findings
+    
+    def _detect_recency_bias(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[BiasFinding]:
+        """Detect over-weighting recent events."""
+        findings = []
+        
+        # Check if rationale heavily emphasizes recent form
+        if "rationale" in inference:
+            rationale = inference["rationale"].lower()
+            
+            # Look for recency language
+            recency_words = ["recent", "last race", "latest", "just", "yesterday"]
+            recency_count = sum(1 for word in recency_words if word in rationale)
+            
+            if recency_count >= 2:
+                findings.append(BiasFinding(
+                    bias_type="RECENCY",
+                    description="Rationale heavily emphasizes recent events (possible recency bias)",
+                    evidence={
+                        "inference_artifact_id": inference_artifact.id,
+                        "recency_count": recency_count,
+                    },
+                    severity="INFO",
+                ))
+        
+        return findings
+    
+    def _detect_overconfidence(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[BiasFinding]:
+        """Detect unjustified high confidence."""
+        findings = []
+        
+        # Check for high confidence with low signal
+        if "confidence" in inference and "signal_strength" in inference:
+            confidence = inference["confidence"]
+            signal_strength = inference["signal_strength"]
+            
+            if confidence > 0.8 and signal_strength < 0.5:
+                findings.append(BiasFinding(
+                    bias_type="OVERCONFIDENCE",
+                    description=f"High confidence ({confidence:.2f}) with low signal ({signal_strength:.2f})",
+                    evidence={
+                        "inference_artifact_id": inference_artifact.id,
+                        "confidence": confidence,
+                        "signal_strength": signal_strength,
+                    },
+                    severity="WARNING",
+                ))
+        
+        return findings
+    
+    def _detect_herd_mentality(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[BiasFinding]:
+        """Detect following market consensus."""
+        findings = []
+        
+        # Check if prediction matches market favorite
+        if "market_favorite" in pre_state and "predictions" in inference:
+            market_favorite = pre_state.get("market_favorite")
+            predictions = inference.get("predictions", [])
+            
+            if predictions:
+                top_prediction = predictions[0].get("runner_name")
+                
+                if market_favorite == top_prediction:
+                    findings.append(BiasFinding(
+                        bias_type="HERD_MENTALITY",
+                        description="Top prediction matches market favorite (possible herd mentality)",
+                        evidence={
+                            "pre_state_artifact_id": pre_state_artifact.id,
+                            "inference_artifact_id": inference_artifact.id,
+                            "market_favorite": market_favorite,
+                            "top_prediction": top_prediction,
+                        },
+                        severity="INFO",
+                    ))
+        
+        return findings
+    
+    def _detect_gamblers_fallacy(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[BiasFinding]:
+        """Detect expecting pattern reversal."""
+        findings = []
+        
+        # Check if rationale mentions "due" or "overdue"
+        if "rationale" in inference:
+            rationale = inference["rationale"].lower()
+            
+            fallacy_words = ["due", "overdue", "turn", "bound to", "must happen"]
+            fallacy_count = sum(1 for word in fallacy_words if word in rationale)
+            
+            if fallacy_count > 0:
+                findings.append(BiasFinding(
+                    bias_type="GAMBLERS_FALLACY",
+                    description="Rationale suggests expecting pattern reversal (gambler's fallacy)",
+                    evidence={
+                        "inference_artifact_id": inference_artifact.id,
+                        "fallacy_words_found": [w for w in fallacy_words if w in rationale],
+                    },
+                    severity="WARNING",
+                ))
+        
+        return findings
+    
+    def propose_patch(
+        self,
+        critique: BiasCritique,
+    ) -> list[BiasPatchProposal]:
+        """
+        Propose patches to mitigate detected biases.
+        
+        Args:
+            critique: Bias critique with findings
+            
+        Returns:
+            List of patch proposals
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY (no auto-apply)
+        """
+        proposals = []
+        
+        for finding in critique.findings:
+            if finding.bias_type == "ANCHORING":
+                proposals.append(BiasPatchProposal(
+                    episode_id=critique.episode_id,
+                    bias_type=finding.bias_type,
+                    proposed_fix="Consider multiple information sources, not just morning odds",
+                    rationale="Anchoring bias leads to over-reliance on first information",
+                ))
+            
+            elif finding.bias_type == "CONFIRMATION":
+                proposals.append(BiasPatchProposal(
+                    episode_id=critique.episode_id,
+                    bias_type=finding.bias_type,
+                    proposed_fix="Actively seek disconfirming evidence in rationale",
+                    rationale="Confirmation bias leads to one-sided analysis",
+                ))
+            
+            elif finding.bias_type == "RECENCY":
+                proposals.append(BiasPatchProposal(
+                    episode_id=critique.episode_id,
+                    bias_type=finding.bias_type,
+                    proposed_fix="Balance recent form with historical performance",
+                    rationale="Recency bias over-weights recent events",
+                ))
+            
+            elif finding.bias_type == "OVERCONFIDENCE":
+                proposals.append(BiasPatchProposal(
+                    episode_id=critique.episode_id,
+                    bias_type=finding.bias_type,
+                    proposed_fix="Calibrate confidence to match signal strength",
+                    rationale="Overconfidence leads to unjustified certainty",
+                ))
+            
+            elif finding.bias_type == "HERD_MENTALITY":
+                proposals.append(BiasPatchProposal(
+                    episode_id=critique.episode_id,
+                    bias_type=finding.bias_type,
+                    proposed_fix="Develop independent analysis, not just follow market",
+                    rationale="Herd mentality reduces edge and increases correlation",
+                ))
+            
+            elif finding.bias_type == "GAMBLERS_FALLACY":
+                proposals.append(BiasPatchProposal(
+                    episode_id=critique.episode_id,
+                    bias_type=finding.bias_type,
+                    proposed_fix="Remove language suggesting pattern reversal expectations",
+                    rationale="Gambler's fallacy assumes independent events are correlated",
+                ))
+        
+        return proposals
+
+
+__all__ = [
+    "BiasFinding",
+    "BiasCritique",
+    "BiasPatchProposal",
+    "CognitiveBiasCritic",
+]

--- a/src/v13/critics/decision_critic.py
+++ b/src/v13/critics/decision_critic.py
@@ -1,0 +1,453 @@
+"""
+VÉLØ V13 - Decision Critic
+
+Post-hoc audit of decision rationale (incoherence, narrative drift, rule violations, overreach).
+
+Detection Capabilities:
+- Incoherence (decision contradicts internal signals)
+- Narrative drift (rationale mentions non-existent features or outcome terms)
+- Rule violations (STRIKE in chaos, low confidence STRIKE, missing rationale)
+- Overreach (overconfidence, insufficient signal support)
+- Missing rationale (no explanation provided)
+- Confidence mismatch (stated confidence doesn't match score distribution)
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+Doctrine: DOCTRINE_CRITIC_AUTHORITY
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..doctrine import enforce_read_only, enforce_episode_bound
+from ..episodes.schema import Episode, EpisodeArtifact, ArtifactType
+
+
+@dataclass
+class DecisionFinding:
+    """A single decision rationale finding."""
+    finding_type: str  # INCOHERENCE, NARRATIVE_DRIFT, RULE_VIOLATION, etc.
+    description: str
+    evidence: dict[str, Any]  # Episode artifact citations
+    severity: str  # INFO, WARNING, CRITICAL
+
+
+@dataclass
+class DecisionCritique:
+    """Result of decision rationale critique."""
+    episode_id: str
+    findings: list[DecisionFinding]
+    is_coherent: bool
+    total_issues: int
+
+
+@dataclass
+class DecisionPatchProposal:
+    """Proposed patch to fix decision issues."""
+    episode_id: str
+    finding_type: str
+    proposed_fix: str
+    rationale: str
+
+
+class DecisionCritic:
+    """
+    Read-only critic that audits decision rationale.
+    
+    Doctrine:
+    - Read-only (no state mutation)
+    - Episode-bound (all findings cite artifacts)
+    - No auto-apply (emits proposals only)
+    - Post-hoc audit only (never intervenes)
+    - Zero action authority
+    """
+    
+    @enforce_read_only
+    @enforce_episode_bound
+    def critique(
+        self,
+        episode: Episode,
+        artifacts: list[EpisodeArtifact],
+    ) -> DecisionCritique:
+        """
+        Audit decision rationale in episode artifacts.
+        
+        Args:
+            episode: Episode to critique
+            artifacts: All artifacts for this episode
+            
+        Returns:
+            DecisionCritique with findings
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY
+        """
+        findings: list[DecisionFinding] = []
+        
+        # Get PRE_STATE and INFERENCE artifacts
+        pre_state_artifact = next(
+            (a for a in artifacts if a.artifact_type == ArtifactType.PRE_STATE),
+            None
+        )
+        inference_artifact = next(
+            (a for a in artifacts if a.artifact_type == ArtifactType.INFERENCE),
+            None
+        )
+        
+        if not pre_state_artifact or not inference_artifact:
+            return DecisionCritique(
+                episode_id=episode.id,
+                findings=[],
+                is_coherent=True,
+                total_issues=0,
+            )
+        
+        pre_state = pre_state_artifact.payload
+        inference = inference_artifact.payload
+        
+        # Check for incoherence
+        findings.extend(self._detect_incoherence(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for narrative drift
+        findings.extend(self._detect_narrative_drift(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for rule violations
+        findings.extend(self._detect_rule_violations(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for overreach
+        findings.extend(self._detect_overreach(
+            episode, pre_state_artifact, inference_artifact, pre_state, inference
+        ))
+        
+        # Check for missing rationale
+        findings.extend(self._detect_missing_rationale(
+            episode, inference_artifact, inference
+        ))
+        
+        # Check for confidence mismatch
+        findings.extend(self._detect_confidence_mismatch(
+            episode, inference_artifact, inference
+        ))
+        
+        return DecisionCritique(
+            episode_id=episode.id,
+            findings=findings,
+            is_coherent=len([f for f in findings if f.severity == "CRITICAL"]) == 0,
+            total_issues=len(findings),
+        )
+    
+    def _detect_incoherence(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[DecisionFinding]:
+        """Detect decision contradicting internal signals."""
+        findings = []
+        
+        # Check if STRIKE decision contradicts internal signals
+        if inference.get("verdict") == "STRIKE":
+            internal_signals = inference.get("internal_signals", {})
+            
+            # Check for chaos warning
+            if internal_signals.get("chaos_warning") == True:
+                findings.append(DecisionFinding(
+                    finding_type="INCOHERENCE",
+                    description="STRIKE decision despite chaos warning",
+                    evidence={
+                        "pre_state_artifact_id": pre_state_artifact.id,
+                        "inference_artifact_id": inference_artifact.id,
+                        "verdict": "STRIKE",
+                        "chaos_warning": True,
+                    },
+                    severity="WARNING",
+                ))
+            
+            # Check for leakage detected
+            if internal_signals.get("leakage_detected") == True:
+                findings.append(DecisionFinding(
+                    finding_type="INCOHERENCE",
+                    description="STRIKE decision despite leakage detection",
+                    evidence={
+                        "pre_state_artifact_id": pre_state_artifact.id,
+                        "inference_artifact_id": inference_artifact.id,
+                        "verdict": "STRIKE",
+                        "leakage_detected": True,
+                    },
+                    severity="CRITICAL",
+                ))
+        
+        return findings
+    
+    def _detect_narrative_drift(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[DecisionFinding]:
+        """Detect rationale mentioning non-existent features or outcome terms."""
+        findings = []
+        
+        if "rationale" not in inference:
+            return findings
+        
+        rationale = inference["rationale"].lower()
+        features = pre_state.get("features", {})
+        
+        # Check for outcome terms in rationale
+        outcome_terms = ["winner", "result", "finishing position", "actual time", "isp"]
+        for term in outcome_terms:
+            if term in rationale:
+                findings.append(DecisionFinding(
+                    finding_type="NARRATIVE_DRIFT",
+                    description=f"Rationale mentions outcome term '{term}'",
+                    evidence={
+                        "inference_artifact_id": inference_artifact.id,
+                        "outcome_term": term,
+                    },
+                    severity="WARNING",
+                ))
+        
+        # Check for non-existent features mentioned in rationale
+        # (This is a simplified check - in production, use NER or feature extraction)
+        feature_names = set(features.keys())
+        mentioned_features = [word for word in rationale.split() if word in feature_names]
+        
+        if len(mentioned_features) == 0 and len(features) > 0:
+            findings.append(DecisionFinding(
+                finding_type="NARRATIVE_DRIFT",
+                description="Rationale does not reference any actual features",
+                evidence={
+                    "inference_artifact_id": inference_artifact.id,
+                    "total_features": len(features),
+                    "mentioned_features": 0,
+                },
+                severity="INFO",
+            ))
+        
+        return findings
+    
+    def _detect_rule_violations(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[DecisionFinding]:
+        """Detect rule violations (STRIKE in chaos, low confidence STRIKE, etc.)."""
+        findings = []
+        
+        verdict = inference.get("verdict")
+        confidence = inference.get("confidence", 0)
+        chaos_level = pre_state.get("chaos_level", 0)
+        
+        # Rule: No STRIKE in high chaos
+        if verdict == "STRIKE" and chaos_level > 0.7:
+            findings.append(DecisionFinding(
+                finding_type="RULE_VIOLATION",
+                description=f"STRIKE decision in high chaos environment (chaos_level={chaos_level:.2f})",
+                evidence={
+                    "pre_state_artifact_id": pre_state_artifact.id,
+                    "inference_artifact_id": inference_artifact.id,
+                    "verdict": "STRIKE",
+                    "chaos_level": chaos_level,
+                },
+                severity="CRITICAL",
+            ))
+        
+        # Rule: No STRIKE with low confidence
+        if verdict == "STRIKE" and confidence < 0.6:
+            findings.append(DecisionFinding(
+                finding_type="RULE_VIOLATION",
+                description=f"STRIKE decision with low confidence ({confidence:.2f})",
+                evidence={
+                    "inference_artifact_id": inference_artifact.id,
+                    "verdict": "STRIKE",
+                    "confidence": confidence,
+                },
+                severity="CRITICAL",
+            ))
+        
+        return findings
+    
+    def _detect_overreach(
+        self,
+        episode: Episode,
+        pre_state_artifact: EpisodeArtifact,
+        inference_artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+        inference: dict[str, Any],
+    ) -> list[DecisionFinding]:
+        """Detect overconfidence or insufficient signal support."""
+        findings = []
+        
+        confidence = inference.get("confidence", 0)
+        signal_strength = inference.get("signal_strength", 0)
+        
+        # Check for overconfidence (>0.95)
+        if confidence > 0.95:
+            findings.append(DecisionFinding(
+                finding_type="OVERREACH",
+                description=f"Overconfidence detected ({confidence:.2f})",
+                evidence={
+                    "inference_artifact_id": inference_artifact.id,
+                    "confidence": confidence,
+                },
+                severity="WARNING",
+            ))
+        
+        # Check for insufficient signal support
+        if confidence > 0.8 and signal_strength < 0.5:
+            findings.append(DecisionFinding(
+                finding_type="OVERREACH",
+                description=f"High confidence ({confidence:.2f}) with low signal ({signal_strength:.2f})",
+                evidence={
+                    "inference_artifact_id": inference_artifact.id,
+                    "confidence": confidence,
+                    "signal_strength": signal_strength,
+                },
+                severity="WARNING",
+            ))
+        
+        return findings
+    
+    def _detect_missing_rationale(
+        self,
+        episode: Episode,
+        inference_artifact: EpisodeArtifact,
+        inference: dict[str, Any],
+    ) -> list[DecisionFinding]:
+        """Detect missing rationale."""
+        findings = []
+        
+        if "rationale" not in inference or not inference["rationale"]:
+            findings.append(DecisionFinding(
+                finding_type="MISSING_RATIONALE",
+                description="No rationale provided for decision",
+                evidence={
+                    "inference_artifact_id": inference_artifact.id,
+                },
+                severity="CRITICAL",
+            ))
+        
+        return findings
+    
+    def _detect_confidence_mismatch(
+        self,
+        episode: Episode,
+        inference_artifact: EpisodeArtifact,
+        inference: dict[str, Any],
+    ) -> list[DecisionFinding]:
+        """Detect stated confidence not matching score distribution."""
+        findings = []
+        
+        confidence = inference.get("confidence", 0)
+        predictions = inference.get("predictions", [])
+        
+        if len(predictions) >= 2:
+            # Calculate score spread (top score - second score)
+            top_score = predictions[0].get("score", 0)
+            second_score = predictions[1].get("score", 0)
+            score_spread = top_score - second_score
+            
+            # High confidence should have high score spread
+            if confidence > 0.8 and score_spread < 0.1:
+                findings.append(DecisionFinding(
+                    finding_type="CONFIDENCE_MISMATCH",
+                    description=f"High confidence ({confidence:.2f}) but low score spread ({score_spread:.2f})",
+                    evidence={
+                        "inference_artifact_id": inference_artifact.id,
+                        "confidence": confidence,
+                        "score_spread": score_spread,
+                    },
+                    severity="WARNING",
+                ))
+        
+        return findings
+    
+    def propose_patch(
+        self,
+        critique: DecisionCritique,
+    ) -> list[DecisionPatchProposal]:
+        """
+        Propose patches to fix decision issues.
+        
+        Args:
+            critique: Decision critique with findings
+            
+        Returns:
+            List of patch proposals
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY (no auto-apply)
+        """
+        proposals = []
+        
+        for finding in critique.findings:
+            if finding.finding_type == "INCOHERENCE":
+                proposals.append(DecisionPatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix="Revise decision to align with internal signals",
+                    rationale="Incoherent decisions undermine system trust",
+                ))
+            
+            elif finding.finding_type == "NARRATIVE_DRIFT":
+                proposals.append(DecisionPatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix="Rewrite rationale to reference actual features only",
+                    rationale="Narrative drift creates false explanations",
+                ))
+            
+            elif finding.finding_type == "RULE_VIOLATION":
+                proposals.append(DecisionPatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix="Change verdict to comply with doctrine rules",
+                    rationale="Rule violations compromise system integrity",
+                ))
+            
+            elif finding.finding_type == "OVERREACH":
+                proposals.append(DecisionPatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix="Calibrate confidence to match signal strength",
+                    rationale="Overreach leads to unjustified risk-taking",
+                ))
+            
+            elif finding.finding_type == "MISSING_RATIONALE":
+                proposals.append(DecisionPatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix="Add rationale explaining decision logic",
+                    rationale="Missing rationale makes decisions unauditable",
+                ))
+            
+            elif finding.finding_type == "CONFIDENCE_MISMATCH":
+                proposals.append(DecisionPatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix="Adjust confidence to match score distribution",
+                    rationale="Confidence mismatch creates false certainty",
+                ))
+        
+        return proposals
+
+
+__all__ = [
+    "DecisionFinding",
+    "DecisionCritique",
+    "DecisionPatchProposal",
+    "DecisionCritic",
+]

--- a/src/v13/critics/feature_extractor.py
+++ b/src/v13/critics/feature_extractor.py
@@ -1,0 +1,373 @@
+"""
+VÉLØ V13 - Feature Extractor Critic
+
+Analyzes feature quality and detects issues (missing, redundant, leaked, invalid).
+
+Detection Capabilities:
+- Missing critical features (chaos_level, compression, field_size, etc.)
+- Redundant features (exact duplicates, high correlation)
+- Feature leakage (outcome information, future timestamps)
+- Invalid values (NaN, Infinity, out-of-range)
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+Doctrine: DOCTRINE_CRITIC_AUTHORITY, DOCTRINE_FEATURE_FIREWALL
+"""
+
+from dataclasses import dataclass
+import math
+from typing import Any
+
+from ..doctrine import enforce_read_only, enforce_episode_bound
+from ..episodes.schema import Episode, EpisodeArtifact, ArtifactType
+
+
+@dataclass
+class FeatureFinding:
+    """A single feature quality finding."""
+    finding_type: str  # MISSING, REDUNDANT, LEAKED, INVALID
+    description: str
+    evidence: dict[str, Any]  # Episode artifact citations
+    severity: str  # INFO, WARNING, CRITICAL
+
+
+@dataclass
+class FeatureCritique:
+    """Result of feature quality critique."""
+    episode_id: str
+    findings: list[FeatureFinding]
+    is_clean: bool
+    total_features: int
+    missing_features: int
+    redundant_features: int
+    leaked_features: int
+    invalid_features: int
+
+
+@dataclass
+class FeaturePatchProposal:
+    """Proposed patch to fix feature issues."""
+    episode_id: str
+    finding_type: str
+    proposed_fix: str
+    rationale: str
+
+
+class FeatureExtractorCritic:
+    """
+    Read-only critic that analyzes feature quality.
+    
+    Doctrine:
+    - Read-only (no state mutation)
+    - Episode-bound (all findings cite artifacts)
+    - No auto-apply (emits proposals only)
+    - Anchored to decisionTime (for leakage detection)
+    - DOCTRINE_FEATURE_FIREWALL: No feature enters model without passing
+    """
+    
+    # Critical features that must be present
+    CRITICAL_FEATURES = [
+        "chaos_level",
+        "compression",
+        "field_size",
+        "distance_yards",
+        "going",
+    ]
+    
+    # Outcome features that indicate leakage
+    OUTCOME_FEATURES = [
+        "isp", "finishing_position", "winner", "result", "actual_time"
+    ]
+    
+    @enforce_read_only
+    @enforce_episode_bound
+    def critique(
+        self,
+        episode: Episode,
+        artifacts: list[EpisodeArtifact],
+    ) -> FeatureCritique:
+        """
+        Analyze feature quality in episode artifacts.
+        
+        Args:
+            episode: Episode to critique
+            artifacts: All artifacts for this episode
+            
+        Returns:
+            FeatureCritique with findings
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY, DOCTRINE_FEATURE_FIREWALL
+        """
+        findings: list[FeatureFinding] = []
+        
+        # Get PRE_STATE artifact
+        pre_state_artifact = next(
+            (a for a in artifacts if a.artifact_type == ArtifactType.PRE_STATE),
+            None
+        )
+        
+        if not pre_state_artifact:
+            return FeatureCritique(
+                episode_id=episode.id,
+                findings=[],
+                is_clean=True,
+                total_features=0,
+                missing_features=0,
+                redundant_features=0,
+                leaked_features=0,
+                invalid_features=0,
+            )
+        
+        pre_state = pre_state_artifact.payload
+        features = pre_state.get("features", {})
+        
+        # Check for missing critical features
+        missing_findings = self._detect_missing_features(
+            episode, pre_state_artifact, features
+        )
+        findings.extend(missing_findings)
+        
+        # Check for redundant features
+        redundant_findings = self._detect_redundant_features(
+            episode, pre_state_artifact, features
+        )
+        findings.extend(redundant_findings)
+        
+        # Check for feature leakage
+        leaked_findings = self._detect_feature_leakage(
+            episode, pre_state_artifact, features
+        )
+        findings.extend(leaked_findings)
+        
+        # Check for invalid values
+        invalid_findings = self._detect_invalid_values(
+            episode, pre_state_artifact, features
+        )
+        findings.extend(invalid_findings)
+        
+        return FeatureCritique(
+            episode_id=episode.id,
+            findings=findings,
+            is_clean=len([f for f in findings if f.severity == "CRITICAL"]) == 0,
+            total_features=len(features),
+            missing_features=len(missing_findings),
+            redundant_features=len(redundant_findings),
+            leaked_features=len(leaked_findings),
+            invalid_features=len(invalid_findings),
+        )
+    
+    def _detect_missing_features(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        features: dict[str, Any],
+    ) -> list[FeatureFinding]:
+        """Detect missing critical features."""
+        findings = []
+        
+        for critical_feature in self.CRITICAL_FEATURES:
+            if critical_feature not in features:
+                findings.append(FeatureFinding(
+                    finding_type="MISSING",
+                    description=f"Critical feature '{critical_feature}' is missing",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "missing_feature": critical_feature,
+                    },
+                    severity="CRITICAL",
+                ))
+        
+        return findings
+    
+    def _detect_redundant_features(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        features: dict[str, Any],
+    ) -> list[FeatureFinding]:
+        """Detect redundant features (exact duplicates)."""
+        findings = []
+        
+        # Check for exact duplicate values
+        value_to_features: dict[Any, list[str]] = {}
+        
+        for feature_name, feature_value in features.items():
+            # Skip non-numeric features
+            if not isinstance(feature_value, (int, float)):
+                continue
+            
+            # Group features by value
+            if feature_value not in value_to_features:
+                value_to_features[feature_value] = []
+            value_to_features[feature_value].append(feature_name)
+        
+        # Report duplicates
+        for value, feature_names in value_to_features.items():
+            if len(feature_names) > 1:
+                findings.append(FeatureFinding(
+                    finding_type="REDUNDANT",
+                    description=f"Features {feature_names} have identical values ({value})",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "redundant_features": feature_names,
+                        "value": value,
+                    },
+                    severity="WARNING",
+                ))
+        
+        return findings
+    
+    def _detect_feature_leakage(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        features: dict[str, Any],
+    ) -> list[FeatureFinding]:
+        """Detect outcome information in features."""
+        findings = []
+        
+        # Check for outcome features
+        for outcome_feature in self.OUTCOME_FEATURES:
+            if outcome_feature in features:
+                findings.append(FeatureFinding(
+                    finding_type="LEAKED",
+                    description=f"Outcome feature '{outcome_feature}' found in features",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "leaked_feature": outcome_feature,
+                        "value": features[outcome_feature],
+                    },
+                    severity="CRITICAL",
+                ))
+        
+        # Check for features with "outcome" or "result" in name
+        for feature_name in features.keys():
+            if any(word in feature_name.lower() for word in ["outcome", "result", "winner", "final"]):
+                findings.append(FeatureFinding(
+                    finding_type="LEAKED",
+                    description=f"Feature name '{feature_name}' suggests outcome information",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "leaked_feature": feature_name,
+                    },
+                    severity="WARNING",
+                ))
+        
+        return findings
+    
+    def _detect_invalid_values(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        features: dict[str, Any],
+    ) -> list[FeatureFinding]:
+        """Detect invalid feature values (NaN, Infinity, out-of-range)."""
+        findings = []
+        
+        for feature_name, feature_value in features.items():
+            # Skip non-numeric features
+            if not isinstance(feature_value, (int, float)):
+                continue
+            
+            # Check for NaN
+            if math.isnan(feature_value):
+                findings.append(FeatureFinding(
+                    finding_type="INVALID",
+                    description=f"Feature '{feature_name}' has NaN value",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "invalid_feature": feature_name,
+                        "value": "NaN",
+                    },
+                    severity="CRITICAL",
+                ))
+            
+            # Check for Infinity
+            elif math.isinf(feature_value):
+                findings.append(FeatureFinding(
+                    finding_type="INVALID",
+                    description=f"Feature '{feature_name}' has Infinity value",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "invalid_feature": feature_name,
+                        "value": "Infinity",
+                    },
+                    severity="CRITICAL",
+                ))
+            
+            # Check for out-of-range values (probabilities should be [0, 1])
+            elif "probability" in feature_name.lower() or "confidence" in feature_name.lower():
+                if feature_value < 0 or feature_value > 1:
+                    findings.append(FeatureFinding(
+                        finding_type="INVALID",
+                        description=f"Probability feature '{feature_name}' is out of range [0, 1]: {feature_value}",
+                        evidence={
+                            "artifact_id": artifact.id,
+                            "invalid_feature": feature_name,
+                            "value": feature_value,
+                        },
+                        severity="WARNING",
+                    ))
+        
+        return findings
+    
+    def propose_patch(
+        self,
+        critique: FeatureCritique,
+    ) -> list[FeaturePatchProposal]:
+        """
+        Propose patches to fix feature issues.
+        
+        Args:
+            critique: Feature critique with findings
+            
+        Returns:
+            List of patch proposals
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY (no auto-apply)
+        """
+        proposals = []
+        
+        for finding in critique.findings:
+            if finding.finding_type == "MISSING":
+                proposals.append(FeaturePatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix=f"Add missing critical feature '{finding.evidence.get('missing_feature')}'",
+                    rationale="Critical features are required for model integrity",
+                ))
+            
+            elif finding.finding_type == "REDUNDANT":
+                proposals.append(FeaturePatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix=f"Remove redundant features: {finding.evidence.get('redundant_features')}",
+                    rationale="Redundant features add noise without information",
+                ))
+            
+            elif finding.finding_type == "LEAKED":
+                proposals.append(FeaturePatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix=f"Remove leaked feature '{finding.evidence.get('leaked_feature')}'",
+                    rationale="Outcome information must not appear in features",
+                ))
+            
+            elif finding.finding_type == "INVALID":
+                proposals.append(FeaturePatchProposal(
+                    episode_id=critique.episode_id,
+                    finding_type=finding.finding_type,
+                    proposed_fix=f"Fix invalid value in feature '{finding.evidence.get('invalid_feature')}'",
+                    rationale="Invalid values (NaN, Infinity, out-of-range) corrupt model",
+                ))
+        
+        return proposals
+
+
+__all__ = [
+    "FeatureFinding",
+    "FeatureCritique",
+    "FeaturePatchProposal",
+    "FeatureExtractorCritic",
+]

--- a/src/v13/critics/leakage_detector.py
+++ b/src/v13/critics/leakage_detector.py
@@ -1,0 +1,338 @@
+"""
+VÉLØ V13 - Leakage Detector Critic
+
+Detects temporal leakage (future information contaminating pre-state).
+
+Leakage Types:
+- Future outcome leakage (ISP, winner, finishing position in pre-state)
+- Future market leakage (market snapshots after decision time)
+- Timestamp violations (data timestamps after decision time)
+- Lookahead bias (suspicious feature names suggesting future knowledge)
+- Training contamination (test set information in training features)
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+Doctrine: DOCTRINE_CRITIC_AUTHORITY, DOCTRINE_EPISTEMIC_TIME
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+from ..doctrine import enforce_read_only, enforce_episode_bound
+from ..episodes.schema import Episode, EpisodeArtifact, ArtifactType
+
+
+@dataclass
+class LeakageFinding:
+    """A single leakage detection finding."""
+    leakage_type: str  # FUTURE_OUTCOME, FUTURE_MARKET, etc.
+    description: str
+    evidence: dict[str, Any]  # Episode artifact citations
+    severity: str  # INFO, WARNING, CRITICAL
+
+
+@dataclass
+class LeakageCritique:
+    """Result of leakage detection critique."""
+    episode_id: str
+    findings: list[LeakageFinding]
+    is_clean: bool
+    total_leaks: int
+
+
+@dataclass
+class LeakagePatchProposal:
+    """Proposed patch to fix leakage."""
+    episode_id: str
+    leakage_type: str
+    proposed_fix: str
+    rationale: str
+
+
+class LeakageDetectorCritic:
+    """
+    Read-only critic that detects temporal leakage.
+    
+    Doctrine:
+    - Read-only (no state mutation)
+    - Episode-bound (all findings cite artifacts)
+    - No auto-apply (emits proposals only)
+    - Anchored to decisionTime (epistemic time)
+    """
+    
+    # Suspicious feature names that suggest lookahead bias
+    LOOKAHEAD_PATTERNS = [
+        "winner", "finishing_position", "final_time", "result",
+        "actual_", "outcome_", "post_race_", "final_"
+    ]
+    
+    # Outcome fields that should never appear in pre-state
+    OUTCOME_FIELDS = [
+        "isp", "finishing_position", "winner", "result", "actual_time"
+    ]
+    
+    @enforce_read_only
+    @enforce_episode_bound
+    def critique(
+        self,
+        episode: Episode,
+        artifacts: list[EpisodeArtifact],
+    ) -> LeakageCritique:
+        """
+        Detect temporal leakage in episode artifacts.
+        
+        Args:
+            episode: Episode to critique
+            artifacts: All artifacts for this episode
+            
+        Returns:
+            LeakageCritique with findings
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY, DOCTRINE_EPISTEMIC_TIME
+        """
+        findings: list[LeakageFinding] = []
+        
+        # Get PRE_STATE artifact
+        pre_state_artifact = next(
+            (a for a in artifacts if a.artifact_type == ArtifactType.PRE_STATE),
+            None
+        )
+        
+        if not pre_state_artifact:
+            return LeakageCritique(
+                episode_id=episode.id,
+                findings=[],
+                is_clean=True,
+                total_leaks=0,
+            )
+        
+        pre_state = pre_state_artifact.payload
+        
+        # Check for future outcome leakage
+        findings.extend(self._detect_future_outcome_leakage(
+            episode, pre_state_artifact, pre_state
+        ))
+        
+        # Check for future market leakage
+        findings.extend(self._detect_future_market_leakage(
+            episode, pre_state_artifact, pre_state
+        ))
+        
+        # Check for timestamp violations
+        findings.extend(self._detect_timestamp_violations(
+            episode, pre_state_artifact, pre_state
+        ))
+        
+        # Check for lookahead bias
+        findings.extend(self._detect_lookahead_bias(
+            episode, pre_state_artifact, pre_state
+        ))
+        
+        return LeakageCritique(
+            episode_id=episode.id,
+            findings=findings,
+            is_clean=len(findings) == 0,
+            total_leaks=len(findings),
+        )
+    
+    def _detect_future_outcome_leakage(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+    ) -> list[LeakageFinding]:
+        """Detect outcome information in pre-state."""
+        findings = []
+        
+        # Check for outcome fields in pre-state
+        for field in self.OUTCOME_FIELDS:
+            if field in pre_state:
+                findings.append(LeakageFinding(
+                    leakage_type="FUTURE_OUTCOME",
+                    description=f"Outcome field '{field}' found in pre-state",
+                    evidence={
+                        "artifact_id": artifact.id,
+                        "field": field,
+                        "value": pre_state[field],
+                    },
+                    severity="CRITICAL",
+                ))
+        
+        # Check runners for outcome fields
+        if "runners" in pre_state:
+            for i, runner in enumerate(pre_state["runners"]):
+                for field in self.OUTCOME_FIELDS:
+                    if field in runner:
+                        findings.append(LeakageFinding(
+                            leakage_type="FUTURE_OUTCOME",
+                            description=f"Outcome field '{field}' found in runner {i} pre-state",
+                            evidence={
+                                "artifact_id": artifact.id,
+                                "runner_index": i,
+                                "field": field,
+                                "value": runner[field],
+                            },
+                            severity="CRITICAL",
+                        ))
+        
+        return findings
+    
+    def _detect_future_market_leakage(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+    ) -> list[LeakageFinding]:
+        """Detect market snapshots after decision time."""
+        findings = []
+        
+        # Check market_snapshots for timestamps after decision time
+        if "market_snapshots" in pre_state:
+            for i, snapshot in enumerate(pre_state["market_snapshots"]):
+                if "timestamp" in snapshot:
+                    snapshot_time = datetime.fromisoformat(
+                        snapshot["timestamp"].replace("Z", "+00:00")
+                    )
+                    
+                    # Compare against episode.decisionTime (EPISTEMIC TIME)
+                    if snapshot_time > episode.decision_time:
+                        findings.append(LeakageFinding(
+                            leakage_type="FUTURE_MARKET",
+                            description=f"Market snapshot {i} is after decision time",
+                            evidence={
+                                "artifact_id": artifact.id,
+                                "snapshot_index": i,
+                                "snapshot_time": snapshot["timestamp"],
+                                "decision_time": episode.decision_time.isoformat(),
+                            },
+                            severity="CRITICAL",
+                        ))
+        
+        return findings
+    
+    def _detect_timestamp_violations(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+    ) -> list[LeakageFinding]:
+        """Detect data timestamps after decision time."""
+        findings = []
+        
+        # Check for timestamp fields in pre-state
+        timestamp_fields = ["timestamp", "updated_at", "fetched_at", "scraped_at"]
+        
+        for field in timestamp_fields:
+            if field in pre_state:
+                try:
+                    data_time = datetime.fromisoformat(
+                        pre_state[field].replace("Z", "+00:00")
+                    )
+                    
+                    # Compare against episode.decisionTime (EPISTEMIC TIME)
+                    if data_time > episode.decision_time:
+                        findings.append(LeakageFinding(
+                            leakage_type="TIMESTAMP_VIOLATION",
+                            description=f"Timestamp field '{field}' is after decision time",
+                            evidence={
+                                "artifact_id": artifact.id,
+                                "field": field,
+                                "data_time": pre_state[field],
+                                "decision_time": episode.decision_time.isoformat(),
+                            },
+                            severity="WARNING",
+                        ))
+                except (ValueError, AttributeError):
+                    # Skip invalid timestamps
+                    pass
+        
+        return findings
+    
+    def _detect_lookahead_bias(
+        self,
+        episode: Episode,
+        artifact: EpisodeArtifact,
+        pre_state: dict[str, Any],
+    ) -> list[LeakageFinding]:
+        """Detect suspicious feature names suggesting future knowledge."""
+        findings = []
+        
+        # Check features for lookahead patterns
+        if "features" in pre_state:
+            for feature_name in pre_state["features"].keys():
+                for pattern in self.LOOKAHEAD_PATTERNS:
+                    if pattern in feature_name.lower():
+                        findings.append(LeakageFinding(
+                            leakage_type="LOOKAHEAD_BIAS",
+                            description=f"Suspicious feature name '{feature_name}' suggests future knowledge",
+                            evidence={
+                                "artifact_id": artifact.id,
+                                "feature_name": feature_name,
+                                "pattern": pattern,
+                            },
+                            severity="WARNING",
+                        ))
+        
+        return findings
+    
+    def propose_patch(
+        self,
+        critique: LeakageCritique,
+    ) -> list[LeakagePatchProposal]:
+        """
+        Propose patches to fix detected leakage.
+        
+        Args:
+            critique: Leakage critique with findings
+            
+        Returns:
+            List of patch proposals
+            
+        Doctrine: DOCTRINE_CRITIC_AUTHORITY (no auto-apply)
+        """
+        proposals = []
+        
+        for finding in critique.findings:
+            if finding.leakage_type == "FUTURE_OUTCOME":
+                proposals.append(LeakagePatchProposal(
+                    episode_id=critique.episode_id,
+                    leakage_type=finding.leakage_type,
+                    proposed_fix=f"Remove field '{finding.evidence.get('field')}' from pre-state",
+                    rationale="Outcome information must not appear in pre-state",
+                ))
+            
+            elif finding.leakage_type == "FUTURE_MARKET":
+                proposals.append(LeakagePatchProposal(
+                    episode_id=critique.episode_id,
+                    leakage_type=finding.leakage_type,
+                    proposed_fix=f"Filter market snapshots to only include timestamps <= decision_time",
+                    rationale="Market data after decision time is future information",
+                ))
+            
+            elif finding.leakage_type == "TIMESTAMP_VIOLATION":
+                proposals.append(LeakagePatchProposal(
+                    episode_id=critique.episode_id,
+                    leakage_type=finding.leakage_type,
+                    proposed_fix=f"Filter data to only include timestamps <= decision_time",
+                    rationale="Data timestamps after decision time indicate temporal leakage",
+                ))
+            
+            elif finding.leakage_type == "LOOKAHEAD_BIAS":
+                proposals.append(LeakagePatchProposal(
+                    episode_id=critique.episode_id,
+                    leakage_type=finding.leakage_type,
+                    proposed_fix=f"Rename or remove feature '{finding.evidence.get('feature_name')}'",
+                    rationale="Feature name suggests future knowledge",
+                ))
+        
+        return proposals
+
+
+__all__ = [
+    "LeakageFinding",
+    "LeakageCritique",
+    "LeakagePatchProposal",
+    "LeakageDetectorCritic",
+]

--- a/src/v13/doctrine.py
+++ b/src/v13/doctrine.py
@@ -1,0 +1,260 @@
+"""
+VÉLØ V13 - Constitutional Doctrine
+
+This module defines the immutable rules that govern VÉLØ's epistem integrity,
+critic behavior, and learning authority.
+
+These are not "features" - they are constitutional constraints.
+Any system that violates these is not VÉLØ.
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+"""
+
+from typing import Final
+
+# =============================================================================
+# EPISTEMIC TIME SEPARATION
+# =============================================================================
+
+DOCTRINE_EPISTEMIC_TIME: Final[str] = """
+RULE: Epistemic time (decisionTime) MUST be separated from execution time (createdAt).
+
+- decisionTime = when the decision was made (knowledge cutoff)
+- createdAt = when the artifact was written (execution timestamp)
+
+All temporal reasoning (leakage detection, causality, backtesting) MUST anchor
+to decisionTime, NEVER createdAt.
+
+Violation of this rule allows temporal contamination and destroys replay integrity.
+"""
+
+# =============================================================================
+# CRITIC AUTHORITY
+# =============================================================================
+
+DOCTRINE_CRITIC_AUTHORITY: Final[str] = """
+RULE: Critics observe, they do not decide.
+
+All critics MUST be:
+- Read-only (no state mutation)
+- Episode-bound (all findings cite artifacts)
+- Non-executive (emit CritiqueResult and PatchProposal only)
+- Post-hoc (audit after the fact, never intervene)
+
+Critics MUST NOT:
+- Make decisions
+- Mutate state
+- Auto-apply patches
+- Block execution
+- Have learning authority
+
+Violation of this rule creates hidden agency and destroys auditability.
+"""
+
+# =============================================================================
+# FEATURE QUALITY FIREWALL
+# =============================================================================
+
+DOCTRINE_FEATURE_FIREWALL: Final[str] = """
+RULE: No feature enters the model unless it survives the Feature Extractor Critic
+with zero CRITICAL findings.
+
+Features MUST be:
+- Complete (no missing critical features)
+- Non-redundant (no duplicates or high correlation)
+- Leak-free (no future information)
+- Valid (no NaN, Infinity, or out-of-range values)
+
+Violation of this rule allows garbage features to poison the model.
+"""
+
+# =============================================================================
+# NO SILENT SELF-MODIFICATION
+# =============================================================================
+
+DOCTRINE_NO_SILENT_MODIFICATION: Final[str] = """
+RULE: No self-modification without explicit human consent.
+
+All changes to doctrine, rules, thresholds, or behavior MUST:
+- Be proposed as PatchProposal objects
+- Route through governance pipeline
+- Require human review
+- Be logged with explicit accept/reject decision
+
+Violation of this rule creates unaccountable drift and founder amnesia.
+"""
+
+# =============================================================================
+# REPLAY INTEGRITY
+# =============================================================================
+
+DOCTRINE_REPLAY_INTEGRITY: Final[str] = """
+RULE: Every episode MUST be deterministically replayable.
+
+Episodes MUST have:
+- Deterministic IDs (function of race_id + engine_version + timestamp_bucket)
+- Context hash (for replay validation)
+- Artifact checksums (SHA256 of payload)
+- Replay hash (SHA256 of concatenated checksums)
+
+Replaying an episode MUST produce identical:
+- Episode IDs
+- Artifact checksums
+- Final replay hash
+
+Violation of this rule destroys historical truth and makes learning untrustworthy.
+"""
+
+# =============================================================================
+# TRUTH BEFORE OPTIMIZATION
+# =============================================================================
+
+DOCTRINE_TRUTH_BEFORE_OPTIMIZATION: Final[str] = """
+RULE: Truth before optimization, memory before learning, doctrine before power.
+
+Priority order (non-negotiable):
+1. Epistemic integrity (can we trust what we know?)
+2. Audit trail (can we explain what we did?)
+3. Doctrine compliance (did we follow the rules?)
+4. Performance (did we win?)
+
+Optimizing for performance before establishing truth creates false confidence
+and undetectable rot.
+
+Violation of this rule is how systems become superstitious.
+"""
+
+# =============================================================================
+# DOCTRINE REGISTRY
+# =============================================================================
+
+DOCTRINE_REGISTRY: Final[dict[str, str]] = {
+    "epistemic_time": DOCTRINE_EPISTEMIC_TIME,
+    "critic_authority": DOCTRINE_CRITIC_AUTHORITY,
+    "feature_firewall": DOCTRINE_FEATURE_FIREWALL,
+    "no_silent_modification": DOCTRINE_NO_SILENT_MODIFICATION,
+    "replay_integrity": DOCTRINE_REPLAY_INTEGRITY,
+    "truth_before_optimization": DOCTRINE_TRUTH_BEFORE_OPTIMIZATION,
+}
+
+
+def get_doctrine(name: str) -> str:
+    """
+    Retrieve a specific doctrine rule by name.
+    
+    Args:
+        name: Doctrine name (e.g., "epistemic_time")
+        
+    Returns:
+        Doctrine text
+        
+    Raises:
+        KeyError: If doctrine name not found
+    """
+    return DOCTRINE_REGISTRY[name]
+
+
+def validate_doctrine_compliance(
+    operation: str,
+    checks: dict[str, bool]
+) -> tuple[bool, list[str]]:
+    """
+    Validate that an operation complies with all doctrine rules.
+    
+    Args:
+        operation: Name of operation being validated
+        checks: Dict of {doctrine_name: is_compliant}
+        
+    Returns:
+        Tuple of (is_compliant, violations)
+        
+    Example:
+        >>> validate_doctrine_compliance(
+        ...     "apply_patch",
+        ...     {
+        ...         "no_silent_modification": False,  # Missing human approval
+        ...         "critic_authority": True,
+        ...     }
+        ... )
+        (False, ["no_silent_modification: Missing human approval"])
+    """
+    violations = []
+    
+    for doctrine_name, is_compliant in checks.items():
+        if not is_compliant:
+            violations.append(f"{doctrine_name}: Violation detected in {operation}")
+    
+    return len(violations) == 0, violations
+
+
+def enforce_read_only(func):
+    """
+    Decorator to enforce read-only behavior on critic methods.
+    
+    Raises:
+        RuntimeError: If method attempts to mutate state
+        
+    Example:
+        >>> @enforce_read_only
+        ... def critique(self, episode_id):
+        ...     # Read-only operations only
+        ...     return critique_result
+    """
+    def wrapper(*args, **kwargs):
+        # TODO: Implement state mutation detection
+        # For now, this is a documentation decorator
+        return func(*args, **kwargs)
+    
+    wrapper.__doc__ = f"[READ-ONLY] {func.__doc__ or ''}"
+    return wrapper
+
+
+def enforce_episode_bound(func):
+    """
+    Decorator to enforce episode-bound behavior on critic methods.
+    
+    All findings MUST cite episode artifacts.
+    
+    Example:
+        >>> @enforce_episode_bound
+        ... def critique(self, episode_id):
+        ...     findings = [...]  # Must include artifact citations
+        ...     return critique_result
+    """
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        
+        # Validate that all findings cite artifacts
+        if hasattr(result, 'findings'):
+            for finding in result.findings:
+                if not hasattr(finding, 'evidence') or not finding.evidence:
+                    raise RuntimeError(
+                        f"Doctrine violation: Finding '{finding.description}' "
+                        f"does not cite episode artifacts"
+                    )
+        
+        return result
+    
+    wrapper.__doc__ = f"[EPISODE-BOUND] {func.__doc__ or ''}"
+    return wrapper
+
+
+# =============================================================================
+# CONSTITUTIONAL GUARANTEES
+# =============================================================================
+
+__all__ = [
+    "DOCTRINE_EPISTEMIC_TIME",
+    "DOCTRINE_CRITIC_AUTHORITY",
+    "DOCTRINE_FEATURE_FIREWALL",
+    "DOCTRINE_NO_SILENT_MODIFICATION",
+    "DOCTRINE_REPLAY_INTEGRITY",
+    "DOCTRINE_TRUTH_BEFORE_OPTIMIZATION",
+    "DOCTRINE_REGISTRY",
+    "get_doctrine",
+    "validate_doctrine_compliance",
+    "enforce_read_only",
+    "enforce_episode_bound",
+]

--- a/src/v13/episodes/constructor.py
+++ b/src/v13/episodes/constructor.py
@@ -1,0 +1,268 @@
+"""
+VÉLØ V13 - Episode Constructor
+
+Converts engine runs into deterministic episodes with replay integrity.
+
+Key Functions:
+- build_episode: Create episode from engine run
+- write_episode_artifacts: Persist PRE_STATE, INFERENCE, OUTCOME artifacts
+- finalize_episode: Update episode with race outcome
+- replay_episode: Generate deterministic replay hash
+- validate_episode_integrity: Validate checksums + replay stability
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+"""
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Optional
+
+from .schema import (
+    Episode,
+    EpisodeArtifact,
+    EpisodeStatus,
+    ArtifactType,
+    validate_epistemic_time_separation,
+    validate_deterministic_id,
+)
+
+
+def build_episode(
+    race_id: str,
+    engine_version: str,
+    decision_time: datetime,
+    context: dict[str, Any],
+) -> Episode:
+    """
+    Create a deterministic episode from engine run.
+    
+    Args:
+        race_id: External race identifier
+        engine_version: Code version that produced this episode
+        decision_time: When the decision was made (EPISTEMIC TIME)
+        context: Input context for replay validation
+        
+    Returns:
+        Episode with deterministic ID
+        
+    Doctrine: DOCTRINE_REPLAY_INTEGRITY, DOCTRINE_EPISTEMIC_TIME
+    """
+    # Bucket timestamp to nearest hour for deterministic ID
+    timestamp_bucket = decision_time.replace(minute=0, second=0, microsecond=0).isoformat()
+    
+    # Generate deterministic episode ID
+    id_input = f"{race_id}:{engine_version}:{timestamp_bucket}"
+    episode_id = hashlib.sha256(id_input.encode()).hexdigest()
+    
+    # Generate context hash for replay validation
+    context_json = json.dumps(context, sort_keys=True)
+    context_hash = hashlib.sha256(context_json.encode()).hexdigest()
+    
+    return Episode(
+        id=episode_id,
+        race_id=race_id,
+        decision_time=decision_time,  # EPISTEMIC TIME
+        created_at=datetime.utcnow(),  # EXECUTION TIME
+        engine_version=engine_version,
+        context_hash=context_hash,
+        replay_hash=None,  # Computed after artifacts are written
+        status=EpisodeStatus.PENDING,
+        regime=None,  # Optional regime classification
+    )
+
+
+def write_episode_artifacts(
+    episode_id: str,
+    pre_state: dict[str, Any],
+    inference: dict[str, Any],
+    outcome: Optional[dict[str, Any]] = None,
+) -> list[EpisodeArtifact]:
+    """
+    Write episode artifacts (PRE_STATE, INFERENCE, OUTCOME).
+    
+    Args:
+        episode_id: Parent episode ID
+        pre_state: Input state before decision
+        inference: Model inference results
+        outcome: Actual race outcome (optional, added later)
+        
+    Returns:
+        List of artifacts with checksums
+        
+    Doctrine: DOCTRINE_REPLAY_INTEGRITY
+    """
+    artifacts = []
+    
+    # PRE_STATE artifact
+    pre_state_json = json.dumps(pre_state, sort_keys=True)
+    pre_state_checksum = hashlib.sha256(pre_state_json.encode()).hexdigest()
+    artifacts.append(EpisodeArtifact(
+        id=f"{episode_id}:pre_state",
+        episode_id=episode_id,
+        artifact_type=ArtifactType.PRE_STATE,
+        payload=pre_state,
+        checksum=pre_state_checksum,
+        created_at=datetime.utcnow(),
+        sequence=1,
+    ))
+    
+    # INFERENCE artifact
+    inference_json = json.dumps(inference, sort_keys=True)
+    inference_checksum = hashlib.sha256(inference_json.encode()).hexdigest()
+    artifacts.append(EpisodeArtifact(
+        id=f"{episode_id}:inference",
+        episode_id=episode_id,
+        artifact_type=ArtifactType.INFERENCE,
+        payload=inference,
+        checksum=inference_checksum,
+        created_at=datetime.utcnow(),
+        sequence=2,
+    ))
+    
+    # OUTCOME artifact (if provided)
+    if outcome:
+        outcome_json = json.dumps(outcome, sort_keys=True)
+        outcome_checksum = hashlib.sha256(outcome_json.encode()).hexdigest()
+        artifacts.append(EpisodeArtifact(
+            id=f"{episode_id}:outcome",
+            episode_id=episode_id,
+            artifact_type=ArtifactType.OUTCOME,
+            payload=outcome,
+            checksum=outcome_checksum,
+            created_at=datetime.utcnow(),
+            sequence=3,
+        ))
+    
+    return artifacts
+
+
+def finalize_episode(
+    episode: Episode,
+    outcome: dict[str, Any],
+) -> tuple[Episode, EpisodeArtifact]:
+    """
+    Update episode with race outcome and mark as COMPLETE.
+    
+    Args:
+        episode: Episode to finalize
+        outcome: Actual race outcome
+        
+    Returns:
+        Tuple of (updated_episode, outcome_artifact)
+        
+    Doctrine: DOCTRINE_REPLAY_INTEGRITY
+    """
+    # Create OUTCOME artifact
+    outcome_json = json.dumps(outcome, sort_keys=True)
+    outcome_checksum = hashlib.sha256(outcome_json.encode()).hexdigest()
+    outcome_artifact = EpisodeArtifact(
+        id=f"{episode.id}:outcome",
+        episode_id=episode.id,
+        artifact_type=ArtifactType.OUTCOME,
+        payload=outcome,
+        checksum=outcome_checksum,
+        created_at=datetime.utcnow(),
+        sequence=3,
+    )
+    
+    # Update episode status
+    episode.status = EpisodeStatus.COMPLETE
+    
+    return episode, outcome_artifact
+
+
+def replay_episode(
+    episode: Episode,
+    artifacts: list[EpisodeArtifact],
+) -> str:
+    """
+    Generate deterministic replay hash from episode artifacts.
+    
+    Args:
+        episode: Episode to replay
+        artifacts: All artifacts for this episode
+        
+    Returns:
+        Replay hash (SHA256 of concatenated checksums)
+        
+    Doctrine: DOCTRINE_REPLAY_INTEGRITY
+    """
+    # Sort artifacts by sequence for deterministic ordering
+    sorted_artifacts = sorted(artifacts, key=lambda a: a.sequence)
+    
+    # Concatenate checksums
+    checksums = [a.checksum for a in sorted_artifacts]
+    checksums_str = ":".join(checksums)
+    
+    # Generate replay hash
+    replay_hash = hashlib.sha256(checksums_str.encode()).hexdigest()
+    
+    return replay_hash
+
+
+def validate_episode_integrity(
+    episode: Episode,
+    artifacts: list[EpisodeArtifact],
+) -> tuple[bool, list[str]]:
+    """
+    Validate episode integrity (checksums + replay stability).
+    
+    Args:
+        episode: Episode to validate
+        artifacts: All artifacts for this episode
+        
+    Returns:
+        Tuple of (is_valid, violations)
+        
+    Doctrine: DOCTRINE_REPLAY_INTEGRITY, DOCTRINE_EPISTEMIC_TIME
+    """
+    violations = []
+    
+    # Validate epistemic time separation for each artifact
+    for artifact in artifacts:
+        is_valid, error = validate_epistemic_time_separation(episode, artifact)
+        if not is_valid:
+            violations.append(f"Epistemic time violation: {error}")
+    
+    # Validate deterministic ID
+    timestamp_bucket = episode.decision_time.replace(minute=0, second=0, microsecond=0).isoformat()
+    if not validate_deterministic_id(
+        episode.race_id,
+        episode.engine_version,
+        timestamp_bucket,
+        episode.id
+    ):
+        violations.append(f"Episode ID is not deterministic: {episode.id}")
+    
+    # Validate artifact checksums
+    for artifact in artifacts:
+        payload_json = json.dumps(artifact.payload, sort_keys=True)
+        computed_checksum = hashlib.sha256(payload_json.encode()).hexdigest()
+        if computed_checksum != artifact.checksum:
+            violations.append(
+                f"Artifact checksum mismatch: {artifact.id} "
+                f"(expected {artifact.checksum}, got {computed_checksum})"
+            )
+    
+    # Validate replay hash
+    if episode.replay_hash:
+        computed_replay_hash = replay_episode(episode, artifacts)
+        if computed_replay_hash != episode.replay_hash:
+            violations.append(
+                f"Replay hash mismatch: "
+                f"(expected {episode.replay_hash}, got {computed_replay_hash})"
+            )
+    
+    return len(violations) == 0, violations
+
+
+__all__ = [
+    "build_episode",
+    "write_episode_artifacts",
+    "finalize_episode",
+    "replay_episode",
+    "validate_episode_integrity",
+]

--- a/src/v13/episodes/schema.py
+++ b/src/v13/episodes/schema.py
@@ -1,0 +1,202 @@
+"""
+VÉLØ V13 - Episode Schema
+
+Defines the episodic memory data model with epistemic time separation.
+
+Key Concepts:
+- Episode: A deterministic snapshot of a race analysis decision
+- decisionTime: When the decision was made (epistemic time)
+- createdAt: When the artifact was written (execution time)
+- Artifact: Sparse storage of episode state (PRE_STATE, INFERENCE, OUTCOME, etc.)
+
+Author: VÉLØ Team
+Date: 2026-01-19
+Status: LOCKED
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class ArtifactType(str, Enum):
+    """Types of episode artifacts for sparse storage."""
+    PRE_STATE = "PRE_STATE"  # Input state before decision
+    INFERENCE = "INFERENCE"  # Model inference results
+    OUTCOME = "OUTCOME"  # Actual race outcome
+    CRITIQUE = "CRITIQUE"  # Post-hoc critic findings
+    PATCH = "PATCH"  # Proposed corrections
+
+
+class EpisodeStatus(str, Enum):
+    """Episode lifecycle status."""
+    PENDING = "PENDING"  # Created, awaiting outcome
+    COMPLETE = "COMPLETE"  # Outcome recorded
+    VALIDATED = "VALIDATED"  # Replay integrity confirmed
+
+
+@dataclass
+class Episode:
+    """
+    Deterministic snapshot of a race analysis decision.
+    
+    Attributes:
+        id: Deterministic ID (SHA256 of race_id + engine_version + timestamp_bucket)
+        race_id: External race identifier
+        decision_time: When the decision was made (EPISTEMIC TIME)
+        created_at: When the artifact was written (EXECUTION TIME)
+        engine_version: Code version that produced this episode
+        context_hash: Hash of input context for replay validation
+        replay_hash: Hash of all artifact checksums (for integrity)
+        status: Episode lifecycle status
+        regime: Optional regime classification (e.g., "CHAOS", "COMPRESSION")
+    """
+    id: str
+    race_id: str
+    decision_time: datetime  # EPISTEMIC TIME - when decision was made
+    created_at: datetime  # EXECUTION TIME - when artifact was written
+    engine_version: str
+    context_hash: str
+    replay_hash: Optional[str]
+    status: EpisodeStatus
+    regime: Optional[str]
+
+
+@dataclass
+class EpisodeArtifact:
+    """
+    Sparse storage of episode state.
+    
+    Attributes:
+        id: Unique artifact ID
+        episode_id: Parent episode ID
+        artifact_type: Type of artifact (PRE_STATE, INFERENCE, etc.)
+        payload: JSON payload (compressed if large)
+        checksum: SHA256 of payload for integrity
+        created_at: When artifact was written
+        sequence: Ordering within episode (for deterministic replay)
+    """
+    id: str
+    episode_id: str
+    artifact_type: ArtifactType
+    payload: dict  # JSON payload
+    checksum: str  # SHA256 of payload
+    created_at: datetime
+    sequence: int
+
+
+@dataclass
+class MemoryIndex:
+    """
+    Fast retrieval index for episode artifacts (Engram-style).
+    
+    Attributes:
+        id: Unique index ID
+        episode_id: Parent episode ID
+        context_key: Searchable context key (e.g., "track:ascot", "chaos:high")
+        artifact_id: Referenced artifact ID
+        relevance_score: Optional relevance score for ranking
+        created_at: When index entry was created
+    """
+    id: str
+    episode_id: str
+    context_key: str
+    artifact_id: str
+    relevance_score: Optional[float]
+    created_at: datetime
+
+
+@dataclass
+class LearningEvent:
+    """
+    Post-race delta (false anchors, missed releases, etc.).
+    
+    Attributes:
+        id: Unique event ID
+        episode_id: Parent episode ID
+        event_type: Type of learning event (e.g., "FALSE_ANCHOR", "MISSED_RELEASE")
+        description: Human-readable description
+        evidence: JSON evidence from episode artifacts
+        severity: Severity level (INFO, WARNING, CRITICAL)
+        created_at: When event was detected
+    """
+    id: str
+    episode_id: str
+    event_type: str
+    description: str
+    evidence: dict  # JSON evidence
+    severity: str  # INFO, WARNING, CRITICAL
+    created_at: datetime
+
+
+# =============================================================================
+# DOCTRINE ENFORCEMENT
+# =============================================================================
+
+def validate_epistemic_time_separation(
+    episode: Episode,
+    artifact: EpisodeArtifact
+) -> tuple[bool, Optional[str]]:
+    """
+    Validate that epistemic time (decisionTime) is separated from execution time (createdAt).
+    
+    Args:
+        episode: Episode to validate
+        artifact: Artifact to validate
+        
+    Returns:
+        Tuple of (is_valid, error_message)
+        
+    Doctrine: DOCTRINE_EPISTEMIC_TIME
+    """
+    # decisionTime must be before or equal to createdAt
+    if episode.decision_time > episode.created_at:
+        return False, f"decisionTime ({episode.decision_time}) is after createdAt ({episode.created_at})"
+    
+    # Artifact createdAt must be after episode decisionTime
+    if artifact.created_at < episode.decision_time:
+        return False, f"Artifact createdAt ({artifact.created_at}) is before episode decisionTime ({episode.decision_time})"
+    
+    return True, None
+
+
+def validate_deterministic_id(
+    race_id: str,
+    engine_version: str,
+    timestamp_bucket: str,
+    expected_id: str
+) -> bool:
+    """
+    Validate that episode ID is deterministic.
+    
+    Args:
+        race_id: External race identifier
+        engine_version: Code version
+        timestamp_bucket: Timestamp bucket (e.g., "2026-01-19T12:00:00Z")
+        expected_id: Expected deterministic ID
+        
+    Returns:
+        True if ID is deterministic, False otherwise
+        
+    Doctrine: DOCTRINE_REPLAY_INTEGRITY
+    """
+    import hashlib
+    
+    # Compute deterministic ID
+    id_input = f"{race_id}:{engine_version}:{timestamp_bucket}"
+    computed_id = hashlib.sha256(id_input.encode()).hexdigest()
+    
+    return computed_id == expected_id
+
+
+__all__ = [
+    "ArtifactType",
+    "EpisodeStatus",
+    "Episode",
+    "EpisodeArtifact",
+    "MemoryIndex",
+    "LearningEvent",
+    "validate_epistemic_time_separation",
+    "validate_deterministic_id",
+]


### PR DESCRIPTION
…ic time separation

- Add episodic memory schema with decisionTime (epistemic time) vs createdAt (execution time)
- Implement 4 read-only critics (Leakage Detector, Cognitive Bias, Feature Extractor, Decision)
- Establish doctrine guards: read-only, episode-bound, no auto-apply, no learning without audit
- Complete cognitive loop: Features → Bias → Leakage → Decision rationale
- All critics emit proposals only (zero action authority)

Doctrine:
- DOCTRINE_CRITIC_AUTHORITY: Critics never decide or mutate
- DOCTRINE_EPISTEMIC_TIME: Decision time ≠ artifact write time
- DOCTRINE_FEATURE_FIREWALL: No feature enters model without passing critic
- DOCTRINE_NO_AUTO_APPLY: All patches require human approval
- DOCTRINE_READ_ONLY: All critics are read-only

Checkpoint: V13_COGNITIVE_LOOP_COMPLETE

## What changed
<!-- Describe the changes in this PR -->
-

## Why
<!-- Explain the business/technical reason for this change -->
-

## How to test
<!-- Steps to verify this works -->
- [ ] `pytest` passes locally
- [ ] `smoke-prod` workflow passes (if production changes)
- [ ] Manual testing completed (describe below)

## Testing notes
<!-- What you tested manually -->
-

## Risk assessment
<!-- Check one -->
- [ ] **Low risk** - Small change, well-tested, easy to rollback
- [ ] **Medium risk** - Moderate change, some uncertainty
- [ ] **High risk** - Large change, affects critical path, or complex

## Deployment notes
<!-- Any special deployment considerations -->
-

## Checklist
- [ ] Code follows project style guidelines
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if needed)
- [ ] No sensitive data in code/logs
- [ ] Reviewed my own PR before requesting review

## Related issues
<!-- Link related issues/PRs -->
Closes #
Related to #

