### PR TITLE
fix: add /api/trigger/sigma-daily endpoint — sigma was never being triggered

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -304,6 +304,81 @@ async def trigger_score_daily(request: Request, x_trigger_secret: str = Header(N
     )
 
 
+# ── Sigma trigger — called by GitHub Actions after races finish ──────────────────────────────────
+@app.post("/api/trigger/sigma-daily", status_code=202)
+async def trigger_sigma_daily(request: Request, x_trigger_secret: str = Header(None)):
+    """
+    Trigger daily sigma reconciliation from GitHub Actions (runs after races finish).
+    Fetches results from Racing API, reconciles against verdicts, writes:
+      - race_results + runner_results
+      - velo_post_race_reviews
+      - sigma_audits
+      - learned_patterns
+      - Playbook G doctrine feed
+      - Zep graph memory
+    Returns 202 immediately — sigma runs as a background subprocess.
+    Required header: X-Trigger-Secret matching TRIGGER_SCORE_SECRET env var.
+    Optional JSON body: {"trigger_source": "...", "target_date": "YYYY-MM-DD"}
+    """
+    import pathlib
+    import subprocess
+    import sys
+
+    trigger_secret = os.getenv("TRIGGER_SCORE_SECRET", "")
+    if not trigger_secret:
+        logger.error("TRIGGER_SCORE_SECRET not configured — sigma trigger endpoint disabled")
+        raise HTTPException(status_code=503, detail="Trigger not configured on this server")
+    if x_trigger_secret != trigger_secret:
+        logger.warning("Sigma trigger attempt with invalid secret")
+        raise HTTPException(status_code=401, detail="Invalid trigger secret")
+
+    body: dict = {}
+    try:
+        body = await request.json()
+    except Exception:
+        pass
+
+    trigger_source = body.get("trigger_source") or "api_manual"
+    target_date = body.get("target_date") or ""
+
+    script_path = pathlib.Path(__file__).parent.parent / "scripts" / "close_sigma_loops.py"
+    if not script_path.exists():
+        raise HTTPException(status_code=500, detail=f"Sigma script not found: {script_path}")
+
+    env = os.environ.copy()
+    env["TRIGGER_SOURCE"] = trigger_source
+
+    cmd = [sys.executable, str(script_path)]
+    if target_date:
+        cmd += ["--date", target_date]
+
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        cwd=str(script_path.parent.parent),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    logger.info(
+        "Sigma reconciliation triggered — source=%s pid=%d target_date=%s",
+        trigger_source,
+        proc.pid,
+        target_date or "today",
+    )
+
+    return JSONResponse(
+        status_code=202,
+        content={
+            "status": "triggered",
+            "service": "sigma-daily",
+            "trigger_source": trigger_source,
+            "target_date": target_date or "today",
+            "pid": proc.pid,
+        },
+    )
+
+
 # Root endpoint
 @app.get("/")
 async def root():

--- a/sigma_workflow_patch.yml
+++ b/sigma_workflow_patch.yml
@@ -1,0 +1,207 @@
+name: VELO Score Daily
+
+# SOURCE-CONTROLLED SCHEDULER — replaces Railway UI cron fragility.
+# This workflow owns the scoring cadence. Railway cron is intentionally
+# NOT configured — this file IS the schedule.
+#
+# Two jobs:
+#   trigger-scoring  — 09:00 UTC Mon-Sat  — runs run_prime_today.py (verdicts)
+#   trigger-sigma    — 21:00 UTC Mon-Sat  — runs close_sigma_loops.py (results + learning)
+#
+# Required GitHub secret: TRIGGER_SCORE_SECRET
+# Required Railway env var: TRIGGER_SCORE_SECRET (same value)
+# Required Railway env var: VELO_ORACLE_URL (or update the env block below)
+
+on:
+  schedule:
+    # 09:00 UTC Mon–Sat — scoring run (verdicts)
+    - cron: '0 9 * * 1-6'
+    # 21:00 UTC Mon–Sat — sigma run (results + reconciliation + learning)
+    - cron: '0 21 * * 1-6'
+
+  workflow_dispatch:
+    inputs:
+      target_date:
+        description: 'Date to score/sigma (YYYY-MM-DD). Leave blank for today.'
+        required: false
+        default: ''
+      run_sigma_only:
+        description: 'Set to "true" to trigger sigma only (skip scoring)'
+        required: false
+        default: 'false'
+
+env:
+  VELO_ORACLE_URL: https://velo-oracle-production.up.railway.app
+
+jobs:
+  # ── Job 1: Scoring (verdicts) ──────────────────────────────────────────────
+  trigger-scoring:
+    name: Trigger Daily Scoring
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Skip scoring job if manually triggered with run_sigma_only=true
+    # Also skip at 21:00 cron (sigma-only hour)
+    if: |
+      (github.event_name == 'schedule' && github.event.schedule == '0 9 * * 1-6') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_sigma_only != 'true')
+
+    steps:
+      - name: Set trigger metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "trigger_source=github_actions_manual" >> $GITHUB_OUTPUT
+          else
+            echo "trigger_source=github_actions_scheduled" >> $GITHUB_OUTPUT
+          fi
+          echo "utc_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Trigger score-daily endpoint
+        id: trigger
+        run: |
+          set -e
+
+          echo "Trigger source : ${{ steps.meta.outputs.trigger_source }}"
+          echo "UTC time       : ${{ steps.meta.outputs.utc_time }}"
+          echo "Target date    : ${{ github.event.inputs.target_date || 'today' }}"
+          echo "Workflow run   : ${{ github.run_id }}"
+          echo ""
+
+          BODY=$(printf '{"trigger_source":"%s","target_date":"%s"}' \
+            "${{ steps.meta.outputs.trigger_source }}" \
+            "${{ github.event.inputs.target_date }}")
+
+          RESPONSE=$(curl -s -o /tmp/trigger_response.json -w "%{http_code}" \
+            --max-time 30 \
+            -X POST \
+            "${{ env.VELO_ORACLE_URL }}/api/trigger/score-daily" \
+            -H "Content-Type: application/json" \
+            -H "X-Trigger-Secret: ${{ secrets.TRIGGER_SCORE_SECRET }}" \
+            -d "$BODY")
+
+          echo "HTTP status: ${RESPONSE}"
+          echo "Response body:"
+          cat /tmp/trigger_response.json
+          echo ""
+
+          if [ "${RESPONSE}" != "202" ]; then
+            echo "FAIL: expected HTTP 202, got ${RESPONSE}"
+            exit 1
+          fi
+
+          echo "SUCCESS: scoring process launched"
+
+      - name: Verify trigger response
+        run: |
+          STATUS=$(python3 -c "import json,sys; d=json.load(open('/tmp/trigger_response.json')); print(d.get('status',''))")
+          SOURCE=$(python3 -c "import json,sys; d=json.load(open('/tmp/trigger_response.json')); print(d.get('trigger_source',''))")
+          PID=$(python3 -c    "import json,sys; d=json.load(open('/tmp/trigger_response.json')); print(d.get('pid',''))")
+
+          echo "status         : ${STATUS}"
+          echo "trigger_source : ${SOURCE}"
+          echo "pid            : ${PID}"
+
+          if [ "${STATUS}" != "triggered" ]; then
+            echo "FAIL: response status was not 'triggered'"
+            exit 1
+          fi
+
+          echo "Trigger confirmed. Run will appear in pipeline_runs with trigger_source=${SOURCE}"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "=== VELO Score Daily — Trigger Summary ==="
+          echo "Event          : ${{ github.event_name }}"
+          echo "Trigger source : ${{ steps.meta.outputs.trigger_source }}"
+          echo "Triggered at   : ${{ steps.meta.outputs.utc_time }}"
+          echo "Workflow run   : https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "Actor          : ${{ github.actor }}"
+
+  # ── Job 2: Sigma (results + reconciliation + learning) ────────────────────
+  trigger-sigma:
+    name: Trigger Sigma Reconciliation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Run at 21:00 cron OR when manually triggered (always run sigma on dispatch)
+    if: |
+      (github.event_name == 'schedule' && github.event.schedule == '0 21 * * 1-6') ||
+      github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Set trigger metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "trigger_source=github_actions_manual" >> $GITHUB_OUTPUT
+          else
+            echo "trigger_source=github_actions_scheduled_sigma" >> $GITHUB_OUTPUT
+          fi
+          echo "utc_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Trigger sigma-daily endpoint
+        id: sigma_trigger
+        run: |
+          set -e
+
+          echo "=== VELO SIGMA RECONCILIATION TRIGGER ==="
+          echo "Trigger source : ${{ steps.meta.outputs.trigger_source }}"
+          echo "UTC time       : ${{ steps.meta.outputs.utc_time }}"
+          echo "Target date    : ${{ github.event.inputs.target_date || 'today' }}"
+          echo "Workflow run   : ${{ github.run_id }}"
+          echo ""
+          echo "This job: fetches results → reconciles verdicts → writes sigma_audits"
+          echo "          → learned_patterns → Playbook G doctrine → Zep graph memory"
+          echo ""
+
+          BODY=$(printf '{"trigger_source":"%s","target_date":"%s"}' \
+            "${{ steps.meta.outputs.trigger_source }}" \
+            "${{ github.event.inputs.target_date }}")
+
+          RESPONSE=$(curl -s -o /tmp/sigma_response.json -w "%{http_code}" \
+            --max-time 30 \
+            -X POST \
+            "${{ env.VELO_ORACLE_URL }}/api/trigger/sigma-daily" \
+            -H "Content-Type: application/json" \
+            -H "X-Trigger-Secret: ${{ secrets.TRIGGER_SCORE_SECRET }}" \
+            -d "$BODY")
+
+          echo "HTTP status: ${RESPONSE}"
+          echo "Response body:"
+          cat /tmp/sigma_response.json
+          echo ""
+
+          if [ "${RESPONSE}" != "202" ]; then
+            echo "FAIL: expected HTTP 202, got ${RESPONSE}"
+            exit 1
+          fi
+
+          echo "SUCCESS: sigma reconciliation process launched"
+
+      - name: Verify sigma trigger response
+        run: |
+          STATUS=$(python3 -c "import json,sys; d=json.load(open('/tmp/sigma_response.json')); print(d.get('status',''))")
+          SERVICE=$(python3 -c "import json,sys; d=json.load(open('/tmp/sigma_response.json')); print(d.get('service',''))")
+          PID=$(python3 -c    "import json,sys; d=json.load(open('/tmp/sigma_response.json')); print(d.get('pid',''))")
+
+          echo "status         : ${STATUS}"
+          echo "service        : ${SERVICE}"
+          echo "pid            : ${PID}"
+
+          if [ "${STATUS}" != "triggered" ]; then
+            echo "FAIL: sigma response status was not 'triggered'"
+            exit 1
+          fi
+
+          echo "Sigma confirmed. Results will land in: race_results, runner_results,"
+          echo "  velo_post_race_reviews, sigma_audits, learned_patterns"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "=== VELO Sigma Daily — Trigger Summary ==="
+          echo "Event          : ${{ github.event_name }}"
+          echo "Trigger source : ${{ steps.meta.outputs.trigger_source }}"
+          echo "Triggered at   : ${{ steps.meta.outputs.utc_time }}"
+          echo "Workflow run   : https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "Actor          : ${{ github.actor }}"


### PR DESCRIPTION
## Root Cause

`close_sigma_loops.py` had no trigger. It existed and was well-written but was never called by any cron, endpoint, or workflow step.

**Result:** Results were not landing in Supabase. No sigma_audits, no velo_post_race_reviews, no learned_patterns, no Playbook G feed. Learning loop was completely silent.

## Fix 1 — `app/main.py` (this PR)

Added `/api/trigger/sigma-daily` endpoint:
- Same pattern as `/api/trigger/score-daily`
- Launches `close_sigma_loops.py` as background subprocess
- Same `TRIGGER_SCORE_SECRET` auth
- Supports optional `target_date` in request body
- Returns 202 immediately with pid

## Fix 2 — `.github/workflows/score-daily.yml` (requires workflows permission)

The workflow file update is in `sigma_workflow_patch.yml` (saved to repo root).
Apply it by copying to `.github/workflows/score-daily.yml` with a token that has workflows scope.

The workflow change adds a second job `trigger-sigma` scheduled at 21:00 UTC Mon-Sat that calls the new endpoint.

## After merging

Railway will redeploy automatically. From the next race day:
- 09:00 UTC — verdicts generated (unchanged)
- 21:00 UTC — results fetched, reconciled, sigma_audits written, learned_patterns updated, Playbook G fed