### PR TITLE
feat(shadow): Mid-Price Hunter shadow module Track A — Issue #78

### DIFF
--- a/scripts/ops/run_prime_today.py
+++ b/scripts/ops/run_prime_today.py
@@ -1203,6 +1203,7 @@ def main():
 
     from app.services.velo_prime_service import persist_race_predictions, score_race_velo_prime
     from src.rpd import RPDv2Engine
+    from src.velo.midprice_hunter import evaluate_and_log as _midprice_evaluate
     from supabase import create_client as _sb_create
     from workers.racing_api_normalizer import normalize_race
 
@@ -1603,6 +1604,26 @@ def main():
                     reasons.append(f"PDF_PLOT_CONVICTION:{pdf_intel['plot_conviction']:.2f}")
 
                 scored.append((race, preds, tier, reasons))
+
+                # ── Mid-Price Hunter shadow evaluation ────────────────────
+                # SHADOW ONLY — never alters velo_prime_prob, tier, routing,
+                # or execution. Runs after score_race_velo_prime() returns.
+                try:
+                    _midprice_evaluate(
+                        race_id=race.get("race_id", ""),
+                        race_date=date_str,
+                        course=race.get("course", ""),
+                        off_time=race.get("off_time", ""),
+                        tier=tier,
+                        top_pick=top.get("horse", ""),
+                        top_vp=top.get("velo_prime_prob"),
+                        top_mds=top.get("market_deception_score"),
+                        top_improvement=top.get("improvement_score"),
+                        top_place_prob=top.get("place_prob"),
+                    )
+                except Exception as _mph_exc:
+                    log.warning("midprice_hunter shadow eval failed: %s", _mph_exc)
+
                 _n_runners_this_race = len(preds)
                 _per_runner_avg_ms = round(_t_score_vp / _n_runners_this_race * 1000, 3) if _n_runners_this_race else 0.0
                 _race_timings.append({

--- a/src/velo/midprice_hunter.py
+++ b/src/velo/midprice_hunter.py
@@ -1,0 +1,208 @@
+"""
+VÉLØ Mid-Price Hunter — SP 3.0–8.5 top-pick shadow suppressor.
+
+Issue #78 Track A. Phase 1 forensic audit (PR #79) identified:
+  - 706 mid-price misses = 54.3% of all misses across 40 race days
+  - MDS is 2.7× higher in wins than mid-price misses (0.173 vs 0.064)
+  - VP≥0.30 + MDS≥0.30 → SR=55%, MP-miss-rate=18%
+  - VP≥0.30 + MDS<0.30 → SR=24%, MP-miss-rate=35%
+
+This module runs AFTER score_race_velo_prime() returns. It reads only
+the top pick's already-computed sidecar scores — it does NOT modify
+velo_prime_prob, decision_tier, assigned_product, or execution_allowed.
+
+Output: per-race shadow verdict written to data/midprice_shadow_ledger.csv.
+
+Hard constraints (permanent — never override):
+  live_scoring_changed = False  always
+  execution_allowed = False     always
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ── Shadow action labels ───────────────────────────────────────────────────
+
+MIDPRICE_SUPPRESS_TOP = "MIDPRICE_SUPPRESS_TOP"
+MIDPRICE_NO_EDGE = "MIDPRICE_NO_EDGE"
+MIDPRICE_SPLIT_RACE = "MIDPRICE_SPLIT_RACE"
+MIDPRICE_CLEAN = "MIDPRICE_CLEAN"
+
+# ── Thresholds (from Phase 1 forensic audit — do not change without audit) ─
+
+_VP_GATE = 0.30  # Minimum VP for SUPPRESS_TOP rule
+_MDS_GATE = 0.30  # MDS below this = deception signal absent
+_MDS_LOW = 0.05  # Near-zero MDS = near-blind
+_IMPROVE_LOW = 0.10  # Improvement absent
+_VP_NO_EDGE_MAX = 0.30  # Upper VP bound for NO_EDGE rule
+_VP_NO_EDGE_MIN = 0.20  # Lower VP bound for NO_EDGE rule
+_VP_SPLIT_MIN = 0.40  # High-conviction zone for SPLIT_RACE
+_MDS_SPLIT_MAX = 0.20  # Weak MDS in high-conviction zone
+_IMPROVE_SPLIT_MAX = 0.20  # Weak improvement in high-conviction zone
+
+# ── Ledger path ────────────────────────────────────────────────────────────
+
+_DEFAULT_LEDGER = Path("data/midprice_shadow_ledger.csv")
+
+_LEDGER_FIELDS = [
+    "created_at",
+    "race_date",
+    "race_id",
+    "course",
+    "off_time",
+    "tier",
+    "top_pick",
+    "top_vp",
+    "top_mds",
+    "top_improvement",
+    "top_place_prob",
+    "shadow_action",
+    "evidence",
+    "live_scoring_changed",
+    "execution_allowed",
+]
+
+
+def evaluate_race(
+    race_id: str,
+    race_date: str,
+    course: str,
+    off_time: str,
+    tier: str,
+    top_pick: str,
+    top_vp: float | None,
+    top_mds: float | None,
+    top_improvement: float | None,
+    top_place_prob: float | None,
+) -> dict[str, Any]:
+    """
+    Evaluate mid-price displacement risk for one race using top-pick signals.
+
+    Returns a shadow verdict dict. Never modifies live scoring state.
+    live_scoring_changed and execution_allowed are always False.
+    """
+    vp = top_vp or 0.0
+    mds = top_mds or 0.0
+    imp = top_improvement or 0.0
+
+    shadow_action, evidence = _apply_rules(tier, vp, mds, imp)
+
+    return {
+        "created_at": datetime.now(tz=UTC).isoformat(),
+        "race_date": race_date,
+        "race_id": race_id,
+        "course": course,
+        "off_time": off_time,
+        "tier": tier,
+        "top_pick": top_pick,
+        "top_vp": top_vp,
+        "top_mds": top_mds,
+        "top_improvement": top_improvement,
+        "top_place_prob": top_place_prob,
+        "shadow_action": shadow_action,
+        "evidence": "|".join(evidence),
+        "live_scoring_changed": False,
+        "execution_allowed": False,
+    }
+
+
+def _apply_rules(
+    tier: str,
+    vp: float,
+    mds: float,
+    imp: float,
+) -> tuple[str, list[str]]:
+    """
+    Return (shadow_action, evidence_tags) for the given signal state.
+
+    Rule priority: SPLIT_RACE > SUPPRESS_TOP > NO_EDGE > CLEAN.
+    All rule thresholds derived from Phase 1 forensic audit (PR #79).
+    """
+    evidence: list[str] = []
+
+    # Rule 3: MIDPRICE_SPLIT_RACE
+    # Tier A + high VP + both MDS and improvement absent
+    # n=45, wins=11 SR=24%, MP-miss-rate=13% — rarest but highest-damage zone
+    if tier == "A" and vp >= _VP_SPLIT_MIN and mds < _MDS_SPLIT_MAX and imp < _IMPROVE_SPLIT_MAX:
+        evidence.append("TIER_A")
+        evidence.append(f"VP_HIGH:{vp:.3f}")
+        evidence.append(f"MDS_WEAK:{mds:.4f}")
+        evidence.append(f"IMP_WEAK:{imp:.4f}")
+        return MIDPRICE_SPLIT_RACE, evidence
+
+    # Rule 1: MIDPRICE_SUPPRESS_TOP
+    # VP≥0.30 + MDS<0.30 — primary rule from Phase 1
+    # n=345, SR=24%, MP-miss-rate=35% (vs 18% when MDS≥0.30)
+    if vp >= _VP_GATE and mds < _MDS_GATE:
+        evidence.append(f"VP_ABOVE_GATE:{vp:.3f}")
+        evidence.append(f"MDS_BELOW_GATE:{mds:.4f}")
+        if mds < _MDS_LOW:
+            evidence.append("MDS_NEAR_ZERO")
+        return MIDPRICE_SUPPRESS_TOP, evidence
+
+    # Rule 2: MIDPRICE_NO_EDGE
+    # Borderline VP + near-zero MDS + low improvement
+    # n=343, SR=18%, MP-miss-rate=50%
+    if _VP_NO_EDGE_MIN <= vp < _VP_NO_EDGE_MAX and mds < _MDS_LOW and imp < _IMPROVE_LOW:
+        evidence.append(f"VP_BORDERLINE:{vp:.3f}")
+        evidence.append(f"MDS_NEAR_ZERO:{mds:.4f}")
+        evidence.append(f"IMP_ABSENT:{imp:.4f}")
+        return MIDPRICE_NO_EDGE, evidence
+
+    return MIDPRICE_CLEAN, [f"VP:{vp:.3f}", f"MDS:{mds:.4f}"]
+
+
+def append_to_ledger(
+    verdict: dict[str, Any],
+    ledger_path: Path | str | None = None,
+) -> None:
+    """
+    Append a shadow verdict row to the mid-price shadow ledger CSV.
+    Creates the file with headers on first write.
+    """
+    path = Path(ledger_path or _DEFAULT_LEDGER)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    write_header = not path.exists() or path.stat().st_size == 0
+    with path.open("a", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_LEDGER_FIELDS, extrasaction="ignore")
+        if write_header:
+            writer.writeheader()
+        writer.writerow(verdict)
+
+
+def evaluate_and_log(
+    race_id: str,
+    race_date: str,
+    course: str,
+    off_time: str,
+    tier: str,
+    top_pick: str,
+    top_vp: float | None,
+    top_mds: float | None,
+    top_improvement: float | None,
+    top_place_prob: float | None,
+    ledger_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """
+    Evaluate and immediately append to the shadow ledger.
+    Convenience wrapper for call sites in run_prime_today.py.
+    """
+    verdict = evaluate_race(
+        race_id=race_id,
+        race_date=race_date,
+        course=course,
+        off_time=off_time,
+        tier=tier,
+        top_pick=top_pick,
+        top_vp=top_vp,
+        top_mds=top_mds,
+        top_improvement=top_improvement,
+        top_place_prob=top_place_prob,
+    )
+    append_to_ledger(verdict, ledger_path=ledger_path)
+    return verdict

--- a/tests/test_midprice_hunter.py
+++ b/tests/test_midprice_hunter.py
@@ -1,0 +1,251 @@
+"""
+Tests for Issue #78 Track A — VÉLØ Mid-Price Hunter shadow module.
+
+Validates:
+  - All three shadow rules fire on correct signal combinations
+  - MIDPRICE_CLEAN fires when signals are strong (MDS≥0.30 at VP≥0.30)
+  - live_scoring_changed and execution_allowed are always False
+  - Ledger append creates file with correct headers
+  - Thresholds match Phase 1 forensic audit findings (PR #79)
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.velo.midprice_hunter import (  # noqa: E402
+    _LEDGER_FIELDS,
+    MIDPRICE_CLEAN,
+    MIDPRICE_NO_EDGE,
+    MIDPRICE_SPLIT_RACE,
+    MIDPRICE_SUPPRESS_TOP,
+    append_to_ledger,
+    evaluate_race,
+)
+
+
+def _race(tier="B", vp=0.35, mds=0.10, imp=0.08, place_prob=0.65):
+    return {
+        "race_id": "rac_test001",
+        "race_date": "2026-05-20",
+        "course": "Ascot",
+        "off_time": "14:30",
+        "tier": tier,
+        "top_pick": "Test Horse",
+        "top_vp": vp,
+        "top_mds": mds,
+        "top_improvement": imp,
+        "top_place_prob": place_prob,
+    }
+
+
+# ── Rule 1: MIDPRICE_SUPPRESS_TOP ─────────────────────────────────────────
+
+
+def test_suppress_top_fires_at_vp30_mds_below_gate():
+    v = evaluate_race(**_race(tier="B", vp=0.35, mds=0.10))
+    assert v["shadow_action"] == MIDPRICE_SUPPRESS_TOP
+
+
+def test_suppress_top_fires_exactly_at_threshold():
+    v = evaluate_race(**_race(tier="B", vp=0.30, mds=0.29))
+    assert v["shadow_action"] == MIDPRICE_SUPPRESS_TOP
+
+
+def test_suppress_top_evidence_contains_gate_tags():
+    v = evaluate_race(**_race(tier="B", vp=0.35, mds=0.10))
+    evid = v["evidence"]
+    assert "VP_ABOVE_GATE" in evid
+    assert "MDS_BELOW_GATE" in evid
+
+
+def test_suppress_top_near_zero_mds_adds_tag():
+    v = evaluate_race(**_race(tier="B", vp=0.35, mds=0.03))
+    assert "MDS_NEAR_ZERO" in v["evidence"]
+
+
+# ── Rule 2: MIDPRICE_NO_EDGE ───────────────────────────────────────────────
+
+
+def test_no_edge_fires_on_borderline_vp_no_signals():
+    v = evaluate_race(**_race(tier="B", vp=0.25, mds=0.02, imp=0.05))
+    assert v["shadow_action"] == MIDPRICE_NO_EDGE
+
+
+def test_no_edge_does_not_fire_if_mds_above_low():
+    # MDS 0.06 > _MDS_LOW=0.05 → should not fire NO_EDGE
+    v = evaluate_race(**_race(tier="B", vp=0.25, mds=0.06, imp=0.05))
+    assert v["shadow_action"] != MIDPRICE_NO_EDGE
+
+
+def test_no_edge_does_not_fire_below_vp_min():
+    v = evaluate_race(**_race(tier="B", vp=0.18, mds=0.02, imp=0.05))
+    assert v["shadow_action"] != MIDPRICE_NO_EDGE
+
+
+def test_no_edge_evidence_has_borderline_tag():
+    v = evaluate_race(**_race(tier="B", vp=0.25, mds=0.02, imp=0.05))
+    assert "VP_BORDERLINE" in v["evidence"]
+
+
+# ── Rule 3: MIDPRICE_SPLIT_RACE ────────────────────────────────────────────
+
+
+def test_split_race_fires_tier_a_high_vp_weak_both():
+    v = evaluate_race(**_race(tier="A", vp=0.45, mds=0.10, imp=0.08))
+    assert v["shadow_action"] == MIDPRICE_SPLIT_RACE
+
+
+def test_split_race_does_not_fire_on_tier_b():
+    v = evaluate_race(**_race(tier="B", vp=0.45, mds=0.10, imp=0.08))
+    assert v["shadow_action"] != MIDPRICE_SPLIT_RACE
+
+
+def test_split_race_does_not_fire_if_mds_above_split_max():
+    v = evaluate_race(**_race(tier="A", vp=0.45, mds=0.25, imp=0.08))
+    assert v["shadow_action"] != MIDPRICE_SPLIT_RACE
+
+
+def test_split_race_evidence_has_tier_a_tag():
+    v = evaluate_race(**_race(tier="A", vp=0.45, mds=0.10, imp=0.08))
+    assert "TIER_A" in v["evidence"]
+
+
+# ── Rule priority: SPLIT_RACE beats SUPPRESS_TOP ──────────────────────────
+
+
+def test_split_race_takes_priority_over_suppress_top():
+    # Tier A + VP≥0.40 + MDS<0.20 + imp<0.20 should fire SPLIT_RACE, not SUPPRESS_TOP
+    v = evaluate_race(**_race(tier="A", vp=0.45, mds=0.10, imp=0.08))
+    assert v["shadow_action"] == MIDPRICE_SPLIT_RACE
+
+
+# ── MIDPRICE_CLEAN (strong signals, no suppression) ────────────────────────
+
+
+def test_clean_fires_when_mds_above_gate_at_vp30():
+    # VP≥0.30 + MDS≥0.30 = the good zone (SR=55%, MP-miss=18%)
+    v = evaluate_race(**_race(tier="B", vp=0.35, mds=0.35, imp=0.25))
+    assert v["shadow_action"] == MIDPRICE_CLEAN
+
+
+def test_clean_fires_when_vp_below_all_gates():
+    v = evaluate_race(**_race(tier="C", vp=0.15, mds=0.05, imp=0.05))
+    assert v["shadow_action"] == MIDPRICE_CLEAN
+
+
+# ── Safety invariants ──────────────────────────────────────────────────────
+
+
+def test_live_scoring_changed_always_false():
+    for tier, vp, mds, imp in [
+        ("A", 0.45, 0.10, 0.08),
+        ("B", 0.35, 0.10, 0.08),
+        ("B", 0.25, 0.02, 0.05),
+        ("B", 0.35, 0.35, 0.25),
+    ]:
+        v = evaluate_race(**_race(tier=tier, vp=vp, mds=mds, imp=imp))
+        assert v["live_scoring_changed"] is False, f"live_scoring_changed True for {tier}/{vp}"
+
+
+def test_execution_allowed_always_false():
+    for tier, vp, mds, imp in [
+        ("A", 0.45, 0.10, 0.08),
+        ("B", 0.35, 0.10, 0.08),
+        ("B", 0.25, 0.02, 0.05),
+        ("B", 0.35, 0.35, 0.25),
+    ]:
+        v = evaluate_race(**_race(tier=tier, vp=vp, mds=mds, imp=imp))
+        assert v["execution_allowed"] is False, f"execution_allowed True for {tier}/{vp}"
+
+
+def test_evaluate_returns_all_required_fields():
+    v = evaluate_race(**_race())
+    required = {
+        "race_id",
+        "race_date",
+        "course",
+        "off_time",
+        "tier",
+        "top_pick",
+        "top_vp",
+        "top_mds",
+        "top_improvement",
+        "top_place_prob",
+        "shadow_action",
+        "evidence",
+        "live_scoring_changed",
+        "execution_allowed",
+    }
+    for field in required:
+        assert field in v, f"Missing field: {field}"
+
+
+# ── Ledger append ──────────────────────────────────────────────────────────
+
+
+def test_ledger_creates_file_with_headers(tmp_path):
+    ledger = tmp_path / "test_ledger.csv"
+    v = evaluate_race(**_race())
+    append_to_ledger(v, ledger_path=ledger)
+    assert ledger.exists()
+    with ledger.open() as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+    assert len(rows) == 1
+    for field in _LEDGER_FIELDS:
+        assert field in rows[0], f"Ledger missing field: {field}"
+
+
+def test_ledger_appends_multiple_rows(tmp_path):
+    ledger = tmp_path / "test_ledger.csv"
+    for _ in range(3):
+        v = evaluate_race(**_race())
+        append_to_ledger(v, ledger_path=ledger)
+    with ledger.open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 3
+
+
+def test_ledger_no_header_duplication_on_append(tmp_path):
+    ledger = tmp_path / "test_ledger.csv"
+    v = evaluate_race(**_race())
+    append_to_ledger(v, ledger_path=ledger)
+    append_to_ledger(v, ledger_path=ledger)
+    lines = ledger.read_text().splitlines()
+    header_lines = [line for line in lines if line.startswith("created_at")]
+    assert len(header_lines) == 1, "Duplicate headers written"
+
+
+def test_ledger_shadow_action_written_correctly(tmp_path):
+    ledger = tmp_path / "test_ledger.csv"
+    v = evaluate_race(**_race(tier="B", vp=0.35, mds=0.10))
+    append_to_ledger(v, ledger_path=ledger)
+    with ledger.open() as fh:
+        row = list(csv.DictReader(fh))[0]
+    assert row["shadow_action"] == MIDPRICE_SUPPRESS_TOP
+    assert row["live_scoring_changed"] == "False"
+    assert row["execution_allowed"] == "False"
+
+
+# ── None handling ──────────────────────────────────────────────────────────
+
+
+def test_none_sidecar_scores_do_not_crash():
+    v = evaluate_race(
+        race_id="rac_x",
+        race_date="2026-05-20",
+        course="Flat",
+        off_time="14:00",
+        tier="B",
+        top_pick="Unknown",
+        top_vp=None,
+        top_mds=None,
+        top_improvement=None,
+        top_place_prob=None,
+    )
+    assert v["shadow_action"] in (MIDPRICE_CLEAN, MIDPRICE_NO_EDGE, MIDPRICE_SUPPRESS_TOP, MIDPRICE_SPLIT_RACE)
+    assert v["live_scoring_changed"] is False


### PR DESCRIPTION
## Summary

- Builds `src/velo/midprice_hunter.py` — three shadow rules from Phase 1 forensic audit
- Wires into `run_prime_today.py` post-scoring (shadow-only, no scoring side effects)
- Creates `data/midprice_shadow_ledger.csv` (append-only forward accumulation)
- 23 tests, all passing

## Rules (derived from Phase 1 forensic audit, PR #79)

| Rule | Trigger | Phase 1 evidence |
|---|---|---|
| `MIDPRICE_SUPPRESS_TOP` | VP≥0.30 + MDS<0.30 | n=345, SR=24%, MP-miss-rate=35% (vs 55%/18% when MDS≥0.30) |
| `MIDPRICE_NO_EDGE` | VP 0.20–0.30 + MDS<0.05 + improvement<0.10 | n=343, SR=18%, MP-miss-rate=50% |
| `MIDPRICE_SPLIT_RACE` | Tier A + VP≥0.40 + MDS<0.20 + improvement<0.20 | highest-damage zone: 73 Tier A misses, avg winner SP=4.87 |

## Hard invariants (enforced in module, never override)

- `live_scoring_changed = False` always
- `execution_allowed = False` always
- Failures caught as warnings — never abort the scoring run

## Constraints

- No live scoring changes ✓
- No ensemble weight changes ✓
- No routing changes ✓
- No execution changes ✓
- Shadow ledger accumulation only ✓

## Next steps

- Issue #80: per-runner snapshot storage (enables Phase 2 delta table / challenger detection)
- n≥30 forward observations before any rule assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)