### PR TITLE
feat(storage): per-runner prediction snapshots — Issue #80

### DIFF
--- a/migrations/create_runner_prediction_snapshots.sql
+++ b/migrations/create_runner_prediction_snapshots.sql
@@ -13,6 +13,7 @@
 
 CREATE TABLE IF NOT EXISTS runner_prediction_snapshots (
     id                      BIGSERIAL PRIMARY KEY,
+    run_id                  TEXT        NOT NULL,  -- batch identity: {date_tag}_{sha8}_{epoch_ms}
     created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     race_date               DATE        NOT NULL,
     race_id                 TEXT        NOT NULL,
@@ -79,6 +80,10 @@ CREATE TABLE IF NOT EXISTS runner_prediction_snapshots (
     live_scoring_changed    BOOLEAN NOT NULL DEFAULT FALSE,
     write_execution_allowed BOOLEAN NOT NULL DEFAULT FALSE
 );
+
+-- Index for batch identity queries (all rows for a specific scoring run)
+CREATE INDEX IF NOT EXISTS idx_rps_run_id
+    ON runner_prediction_snapshots (run_id);
 
 -- Index for Mid-Price Hunter Phase 2 delta queries (winner join by race_id + date)
 CREATE INDEX IF NOT EXISTS idx_rps_race_id_date

--- a/migrations/create_runner_prediction_snapshots.sql
+++ b/migrations/create_runner_prediction_snapshots.sql
@@ -1,0 +1,96 @@
+-- Issue #80: Per-runner prediction snapshot storage
+-- Creates runner_prediction_snapshots table in Supabase.
+--
+-- Purpose: Store full per-runner scored output for every scored race so that
+-- Mid-Price Hunter Phase 2 can compute winner_mds - top_mds delta features,
+-- and Sigma can query full-field runner context instead of only top-pick verdicts.
+--
+-- Safety: this table is append-only storage. It has no write-back path to
+-- live scoring, routing, or execution. live_scoring_changed is always False.
+--
+-- Run once in Supabase SQL Editor or via psql:
+--   psql $DATABASE_URL -f migrations/create_runner_prediction_snapshots.sql
+
+CREATE TABLE IF NOT EXISTS runner_prediction_snapshots (
+    id                      BIGSERIAL PRIMARY KEY,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    race_date               DATE        NOT NULL,
+    race_id                 TEXT        NOT NULL,
+    course                  TEXT,
+    off_time                TEXT,
+    tier                    TEXT,
+    rank                    INTEGER     NOT NULL,  -- 0 = top pick, 1 = second, etc.
+    horse                   TEXT,
+    horse_id                TEXT,
+
+    -- Core scoring outputs
+    velo_prime_prob         NUMERIC(8,6),
+    sqpe_v17_prob           NUMERIC(8,6),
+    market_deception_score  NUMERIC(8,6),
+    improvement_score       NUMERIC(8,6),
+    place_prob              NUMERIC(8,6),
+    longshot_prob           NUMERIC(8,6),
+    release_day_prob        NUMERIC(8,6),
+    comment_intel_score     NUMERIC(8,6),
+    mark_compression_score  NUMERIC(8,6),
+    spotlight_score         NUMERIC(8,6),
+    postdata_score          NUMERIC(8,6),  -- 0% coverage currently; stored when available
+    plot_conviction         NUMERIC(8,6),  -- 0% coverage currently; stored when available
+
+    -- Race context derived at snapshot time
+    top_pick_name           TEXT,
+    top_pick_vp             NUMERIC(8,6),
+    prob_gap                NUMERIC(8,6),  -- top_vp - this_runner_vp (0.0 for rank=0)
+
+    -- Flags
+    cash_run_flag           BOOLEAN,
+    setup_run_flag          BOOLEAN,
+    decoy_support_flag      BOOLEAN,
+    tie_gate_fires          BOOLEAN,
+    tie_gate_tier_upgrade   TEXT,
+
+    -- RPD
+    rpd_tag                 TEXT,
+    rpd_confidence          NUMERIC(6,4),
+    rpd_evidence_codes      JSONB,
+
+    -- RPDC
+    rpdc_primary_tag        TEXT,
+    rpdc_release_score      NUMERIC(6,4),
+    rpdc_cash_window_flag   BOOLEAN,
+    rpdc_tags               JSONB,
+
+    -- Ensemble metadata
+    active_components       JSONB,
+    excluded_from_ensemble  JSONB,
+    assigned_product        TEXT,
+    confidence_level        TEXT,
+    decision_tier           TEXT,
+    execution_allowed       BOOLEAN,
+    race_archetype          TEXT,
+    archetype_confidence    TEXT,
+    router_reasons          JSONB,
+
+    -- Market data (not always populated pre-race)
+    sp_dec                  NUMERIC(8,4),
+    is_fav                  BOOLEAN,
+
+    -- Safety invariants: always False, never writable from outside
+    live_scoring_changed    BOOLEAN NOT NULL DEFAULT FALSE,
+    write_execution_allowed BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- Index for Mid-Price Hunter Phase 2 delta queries (winner join by race_id + date)
+CREATE INDEX IF NOT EXISTS idx_rps_race_id_date
+    ON runner_prediction_snapshots (race_id, race_date);
+
+-- Index for Sigma queries (all runners for a given date)
+CREATE INDEX IF NOT EXISTS idx_rps_race_date
+    ON runner_prediction_snapshots (race_date);
+
+-- Index for horse-level lookups across dates
+CREATE INDEX IF NOT EXISTS idx_rps_horse_date
+    ON runner_prediction_snapshots (horse_id, race_date);
+
+COMMENT ON TABLE runner_prediction_snapshots IS
+    'Full per-runner prediction snapshots. Append-only. No write-back to scoring path. Issue #80.';

--- a/scripts/ops/run_prime_today.py
+++ b/scripts/ops/run_prime_today.py
@@ -1204,6 +1204,7 @@ def main():
     from app.services.velo_prime_service import persist_race_predictions, score_race_velo_prime
     from src.rpd import RPDv2Engine
     from src.velo.midprice_hunter import evaluate_and_log as _midprice_evaluate
+    from src.velo.runner_snapshot_store import write_runner_snapshots as _write_runner_snapshots
     from supabase import create_client as _sb_create
     from workers.racing_api_normalizer import normalize_race
 
@@ -1904,6 +1905,22 @@ def main():
     except Exception as e:
         print(f"\nLocal backup skipped: {e}")
     _timer.mark("local_backup")
+
+    # ── RUNNER SNAPSHOT STORE (Issue #80) ─────────────────────────────────────
+    # STORAGE ONLY — never alters scoring, routing, or execution.
+    # Batch write of all runners across all scored races.
+    # Failure logs a warning and returns 0; never aborts the pipeline.
+    try:
+        _snapshot_n = _write_runner_snapshots(
+            scored=scored,
+            date_str=date_str,
+            date_tag=date_tag,
+            supabase_client=db if persistence_enabled else None,
+        )
+        print(f"\nRUNNER SNAPSHOTS: {_snapshot_n} rows → runner_snapshots_{date_tag}.jsonl")
+    except Exception as _snap_exc:
+        print(f"\nRunner snapshot write skipped: {_snap_exc}")
+    _timer.mark("runner_snapshots", races=len(scored), runners=sum(len(p) for _, p, _, _ in scored))
 
     # ── TIMING AUDIT ──────────────────────────────────────────────────────────
     try:

--- a/scripts/ops/run_prime_today.py
+++ b/scripts/ops/run_prime_today.py
@@ -1204,7 +1204,10 @@ def main():
     from app.services.velo_prime_service import persist_race_predictions, score_race_velo_prime
     from src.rpd import RPDv2Engine
     from src.velo.midprice_hunter import evaluate_and_log as _midprice_evaluate
-    from src.velo.runner_snapshot_store import write_runner_snapshots as _write_runner_snapshots
+    from src.velo.runner_snapshot_store import (
+        build_run_id as _build_run_id,
+        write_runner_snapshots as _write_runner_snapshots,
+    )
     from supabase import create_client as _sb_create
     from workers.racing_api_normalizer import normalize_race
 
@@ -1258,6 +1261,7 @@ def main():
     is_live = racecard_source == "api"
     live_label = "LIVE_API" if is_live else "CACHE"
     commit_sha = get_commit_sha()
+    _snapshot_run_id = _build_run_id(date_tag, commit_sha)
 
     print(f"\n{'=' * 60}")
     print("  SOURCE TRUTH HEADER")
@@ -1915,9 +1919,10 @@ def main():
             scored=scored,
             date_str=date_str,
             date_tag=date_tag,
+            run_id=_snapshot_run_id,
             supabase_client=db if persistence_enabled else None,
         )
-        print(f"\nRUNNER SNAPSHOTS: {_snapshot_n} rows → runner_snapshots_{date_tag}.jsonl")
+        print(f"\nRUNNER SNAPSHOTS: {_snapshot_n} rows → runner_snapshots_{date_tag}_{_snapshot_run_id}.jsonl")
     except Exception as _snap_exc:
         print(f"\nRunner snapshot write skipped: {_snap_exc}")
     _timer.mark("runner_snapshots", races=len(scored), runners=sum(len(p) for _, p, _, _ in scored))

--- a/src/velo/runner_snapshot_store.py
+++ b/src/velo/runner_snapshot_store.py
@@ -5,8 +5,11 @@ Persists full per-runner prediction snapshots for every scored race.
 Storage only — never modifies scoring, routing, or execution.
 
 Output:
-  - Local JSONL: data/runner_snapshots_YYYY_MM_DD.jsonl  (primary)
-  - Supabase: runner_prediction_snapshots table          (best-effort, fails silently)
+  - Local JSONL: data/runner_snapshots_{date_tag}_{run_id}.jsonl  (primary)
+  - Supabase: runner_prediction_snapshots table                   (best-effort, fails silently)
+
+Each snapshot file is uniquely identified by run_id so same-day reruns,
+Railway retries, and partial runs never overwrite each other.
 
 Hard constraints (permanent — never override):
   live_scoring_changed = False  always
@@ -72,9 +75,24 @@ _LIVE_SCORING_CHANGED = False
 _WRITE_EXECUTION_ALLOWED = False
 
 
+def build_run_id(date_tag: str, commit_sha: str) -> str:
+    """
+    Build a deterministic run_id for one scoring batch.
+
+    Format: {date_tag}_{commit_sha[:8]}_{utc_epoch_ms}
+
+    The epoch suffix ensures uniqueness across same-day reruns and
+    Railway retries even when commit_sha is identical.
+    """
+    epoch_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
+    sha8 = (commit_sha or "unknown")[:8]
+    return f"{date_tag}_{sha8}_{epoch_ms}"
+
+
 def _build_snapshot_row(
     pred: dict[str, Any],
     rank: int,
+    run_id: str,
     race_id: str,
     race_date: str,
     course: str,
@@ -85,6 +103,7 @@ def _build_snapshot_row(
     created_at: str,
 ) -> dict[str, Any]:
     row: dict[str, Any] = {
+        "run_id": run_id,
         "created_at": created_at,
         "race_date": race_date,
         "race_id": race_id,
@@ -111,6 +130,7 @@ def write_runner_snapshots(
     scored: list[tuple[dict, list[dict], str, list]],
     date_str: str,
     date_tag: str,
+    run_id: str,
     snapshot_dir: Path | str | None = None,
     supabase_client: Any | None = None,
 ) -> int:
@@ -121,6 +141,7 @@ def write_runner_snapshots(
         scored: list of (race, preds, tier, reasons) tuples from the scoring loop.
         date_str: ISO date string e.g. "2026-05-20".
         date_tag: underscore date tag e.g. "2026_05_20" for filenames.
+        run_id: unique batch identity for this scoring run (see build_run_id()).
         snapshot_dir: override for data/ directory path.
         supabase_client: optional live Supabase client for DB write.
 
@@ -147,6 +168,7 @@ def write_runner_snapshots(
                 _build_snapshot_row(
                     pred=pred,
                     rank=rank,
+                    run_id=run_id,
                     race_id=race_id,
                     race_date=date_str,
                     course=course,
@@ -162,7 +184,7 @@ def write_runner_snapshots(
         log.warning("runner_snapshot_store: no rows to write")
         return 0
 
-    written = _write_local_jsonl(rows, date_tag, snapshot_dir)
+    written = _write_local_jsonl(rows, date_tag, run_id, snapshot_dir)
     _write_supabase(rows, supabase_client)
     return written
 
@@ -170,12 +192,13 @@ def write_runner_snapshots(
 def _write_local_jsonl(
     rows: list[dict[str, Any]],
     date_tag: str,
+    run_id: str,
     snapshot_dir: Path | str | None,
 ) -> int:
     try:
         base = Path(snapshot_dir or _DEFAULT_SNAPSHOT_DIR)
         base.mkdir(parents=True, exist_ok=True)
-        out_path = base / f"runner_snapshots_{date_tag}.jsonl"
+        out_path = base / f"runner_snapshots_{date_tag}_{run_id}.jsonl"
         with out_path.open("w", encoding="utf-8") as fh:
             for row in rows:
                 fh.write(json.dumps(row, default=str) + "\n")

--- a/src/velo/runner_snapshot_store.py
+++ b/src/velo/runner_snapshot_store.py
@@ -12,9 +12,10 @@ Each snapshot file is uniquely identified by run_id so same-day reruns,
 Railway retries, and partial runs never overwrite each other.
 
 Hard constraints (permanent — never override):
-  live_scoring_changed = False  always
-  execution_allowed    = False  always
-  write failure        = warning only, never raises into scoring path
+  live_scoring_changed    = False  always (storage invariant, not copied from pred)
+  write_execution_allowed = False  always (storage invariant, not copied from pred)
+  execution_allowed       = stored verbatim from pred (runner's own field, not overridden)
+  write failure           = warning only, never raises into scoring path
 """
 
 from __future__ import annotations
@@ -217,6 +218,6 @@ def _write_supabase(
         return
     try:
         supabase_client.table("runner_prediction_snapshots").insert(rows).execute()
-        log.info("runner_snapshot_store: upserted %d rows to Supabase", len(rows))
+        log.info("runner_snapshot_store: inserted %d rows to Supabase", len(rows))
     except Exception as exc:
         log.warning("runner_snapshot_store: Supabase write failed (non-fatal): %s", exc)

--- a/src/velo/runner_snapshot_store.py
+++ b/src/velo/runner_snapshot_store.py
@@ -1,0 +1,199 @@
+"""
+VÉLØ Runner Snapshot Store — Issue #80.
+
+Persists full per-runner prediction snapshots for every scored race.
+Storage only — never modifies scoring, routing, or execution.
+
+Output:
+  - Local JSONL: data/runner_snapshots_YYYY_MM_DD.jsonl  (primary)
+  - Supabase: runner_prediction_snapshots table          (best-effort, fails silently)
+
+Hard constraints (permanent — never override):
+  live_scoring_changed = False  always
+  execution_allowed    = False  always
+  write failure        = warning only, never raises into scoring path
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_SNAPSHOT_DIR = Path("data")
+
+# Fields extracted from each runner pred dict
+_PRED_FIELDS = [
+    "horse",
+    "horse_id",
+    "velo_prime_prob",
+    "sqpe_v17_prob",
+    "market_deception_score",
+    "improvement_score",
+    "place_prob",
+    "longshot_prob",
+    "release_day_prob",
+    "comment_intel_score",
+    "mark_compression_score",
+    "spotlight_score",
+    "postdata_score",
+    "plot_conviction",
+    "cash_run_flag",
+    "setup_run_flag",
+    "decoy_support_flag",
+    "rpd_tag",
+    "rpd_confidence",
+    "rpd_evidence_codes",
+    "rpdc_primary_tag",
+    "rpdc_release_score",
+    "rpdc_cash_window_flag",
+    "rpdc_tags",
+    "tie_gate_fires",
+    "tie_gate_tier_upgrade",
+    "active_components",
+    "excluded_from_ensemble",
+    "assigned_product",
+    "confidence_level",
+    "decision_tier",
+    "execution_allowed",
+    "race_archetype",
+    "archetype_confidence",
+    "router_reasons",
+    "sp_dec",
+    "is_fav",
+]
+
+# Safety invariants written on every snapshot row
+_LIVE_SCORING_CHANGED = False
+_WRITE_EXECUTION_ALLOWED = False
+
+
+def _build_snapshot_row(
+    pred: dict[str, Any],
+    rank: int,
+    race_id: str,
+    race_date: str,
+    course: str,
+    off_time: str,
+    tier: str,
+    top_pick_name: str,
+    top_pick_vp: float | None,
+    created_at: str,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "created_at": created_at,
+        "race_date": race_date,
+        "race_id": race_id,
+        "course": course,
+        "off_time": off_time,
+        "tier": tier,
+        "rank": rank,
+        "top_pick_name": top_pick_name,
+        "top_pick_vp": top_pick_vp,
+        "prob_gap": (
+            round((top_pick_vp or 0.0) - float(pred.get("velo_prime_prob") or 0.0), 6)
+            if rank > 0
+            else 0.0
+        ),
+        "live_scoring_changed": _LIVE_SCORING_CHANGED,
+        "write_execution_allowed": _WRITE_EXECUTION_ALLOWED,
+    }
+    for field in _PRED_FIELDS:
+        row[field] = pred.get(field)
+    return row
+
+
+def write_runner_snapshots(
+    scored: list[tuple[dict, list[dict], str, list]],
+    date_str: str,
+    date_tag: str,
+    snapshot_dir: Path | str | None = None,
+    supabase_client: Any | None = None,
+) -> int:
+    """
+    Batch-write full per-runner prediction snapshots for all scored races.
+
+    Args:
+        scored: list of (race, preds, tier, reasons) tuples from the scoring loop.
+        date_str: ISO date string e.g. "2026-05-20".
+        date_tag: underscore date tag e.g. "2026_05_20" for filenames.
+        snapshot_dir: override for data/ directory path.
+        supabase_client: optional live Supabase client for DB write.
+
+    Returns:
+        Number of runner rows written to local JSONL. 0 on total failure.
+
+    Never raises — all errors are logged as warnings.
+    """
+    created_at = datetime.now(tz=UTC).isoformat()
+    rows: list[dict[str, Any]] = []
+
+    for race, preds, tier, _reasons in scored:
+        if not preds:
+            continue
+        race_id = race.get("race_id", "")
+        course = race.get("course", "")
+        off_time = race.get("off_time", "")
+        top = preds[0]
+        top_pick_name: str = top.get("horse", "")
+        top_pick_vp: float | None = top.get("velo_prime_prob")
+
+        for rank, pred in enumerate(preds):
+            rows.append(
+                _build_snapshot_row(
+                    pred=pred,
+                    rank=rank,
+                    race_id=race_id,
+                    race_date=date_str,
+                    course=course,
+                    off_time=off_time,
+                    tier=tier,
+                    top_pick_name=top_pick_name,
+                    top_pick_vp=top_pick_vp,
+                    created_at=created_at,
+                )
+            )
+
+    if not rows:
+        log.warning("runner_snapshot_store: no rows to write")
+        return 0
+
+    written = _write_local_jsonl(rows, date_tag, snapshot_dir)
+    _write_supabase(rows, supabase_client)
+    return written
+
+
+def _write_local_jsonl(
+    rows: list[dict[str, Any]],
+    date_tag: str,
+    snapshot_dir: Path | str | None,
+) -> int:
+    try:
+        base = Path(snapshot_dir or _DEFAULT_SNAPSHOT_DIR)
+        base.mkdir(parents=True, exist_ok=True)
+        out_path = base / f"runner_snapshots_{date_tag}.jsonl"
+        with out_path.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row, default=str) + "\n")
+        log.info("runner_snapshot_store: wrote %d rows → %s", len(rows), out_path.name)
+        return len(rows)
+    except Exception as exc:
+        log.warning("runner_snapshot_store: local JSONL write failed: %s", exc)
+        return 0
+
+
+def _write_supabase(
+    rows: list[dict[str, Any]],
+    supabase_client: Any | None,
+) -> None:
+    if supabase_client is None:
+        return
+    try:
+        supabase_client.table("runner_prediction_snapshots").insert(rows).execute()
+        log.info("runner_snapshot_store: upserted %d rows to Supabase", len(rows))
+    except Exception as exc:
+        log.warning("runner_snapshot_store: Supabase write failed (non-fatal): %s", exc)

--- a/tests/test_runner_snapshot_store.py
+++ b/tests/test_runner_snapshot_store.py
@@ -3,10 +3,12 @@ Tests for Issue #80 — VÉLØ Runner Snapshot Store.
 
 Validates:
   - JSONL file created with correct row count per runner
-  - All required fields present in each row
+  - All required fields present in each row (including run_id)
   - Rank 0 = top pick, rank N = Nth runner
   - prob_gap = 0.0 for rank 0, top_vp - runner_vp for rank > 0
   - live_scoring_changed and write_execution_allowed always False
+  - All rows in same batch share run_id
+  - Same-day two writes produce separate files (no overwrite)
   - Write failure does NOT raise into caller (safety invariant)
   - Supabase client failure does NOT raise into caller
   - Empty preds list is handled gracefully
@@ -21,7 +23,17 @@ from unittest.mock import MagicMock
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from src.velo.runner_snapshot_store import write_runner_snapshots  # noqa: E402
+from src.velo.runner_snapshot_store import (  # noqa: E402
+    build_run_id,
+    write_runner_snapshots,
+)
+
+# Stable run_id used across all tests for filename predictability
+_RUN_ID = "2026_05_20_abc12345_1716220800000"
+_DATE_TAG = "2026_05_20"
+_DATE_STR = "2026-05-20"
+_JSONL_NAME = f"runner_snapshots_{_DATE_TAG}_{_RUN_ID}.jsonl"
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -86,14 +98,19 @@ def _read_rows(path):
     return [json.loads(line) for line in path.read_text().splitlines()]
 
 
+def _write(scored, tmp_path, run_id=_RUN_ID):
+    return write_runner_snapshots(
+        scored, _DATE_STR, _DATE_TAG, run_id=run_id, snapshot_dir=tmp_path
+    )
+
+
 # ── Row count and file creation ────────────────────────────────────────────────
 
 
 def test_creates_jsonl_file(tmp_path):
-    scored = _scored_1race_2runners()
-    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    n = _write(_scored_1race_2runners(), tmp_path)
     assert n == 2
-    assert (tmp_path / "runner_snapshots_2026_05_20.jsonl").exists()
+    assert (tmp_path / _JSONL_NAME).exists()
 
 
 def test_row_count_matches_total_runners(tmp_path):
@@ -103,49 +120,96 @@ def test_row_count_matches_total_runners(tmp_path):
         (race1, [_pred("A1"), _pred("A2"), _pred("A3")], "A", []),
         (race2, [_pred("B1"), _pred("B2")], "B", []),
     ]
-    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    n = _write(scored, tmp_path)
     assert n == 5
-    assert len((tmp_path / "runner_snapshots_2026_05_20.jsonl").read_text().splitlines()) == 5
+    assert len((tmp_path / _JSONL_NAME).read_text().splitlines()) == 5
 
 
 def test_each_line_is_valid_json(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    for line in (tmp_path / "runner_snapshots_2026_05_20.jsonl").read_text().splitlines():
+    _write(_scored_1race_2runners(), tmp_path)
+    for line in (tmp_path / _JSONL_NAME).read_text().splitlines():
         assert isinstance(json.loads(line), dict)
+
+
+# ── run_id invariants ─────────────────────────────────────────────────────────
+
+
+def test_every_row_has_run_id(tmp_path):
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
+    for row in rows:
+        assert "run_id" in row, "row missing run_id"
+        assert row["run_id"] == _RUN_ID
+
+
+def test_all_rows_in_same_batch_share_run_id(tmp_path):
+    race1 = _race("rac_001")
+    race2 = _race("rac_002", course="Newmarket", off_time="15:00")
+    scored = [
+        (race1, [_pred("A1"), _pred("A2")], "A", []),
+        (race2, [_pred("B1")], "B", []),
+    ]
+    _write(scored, tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
+    assert len(rows) == 3
+    run_ids = {r["run_id"] for r in rows}
+    assert run_ids == {_RUN_ID}, f"Expected single run_id, got {run_ids}"
+
+
+def test_same_day_two_writes_produce_separate_files(tmp_path):
+    scored = _scored_1race_2runners()
+    run_id_1 = "2026_05_20_abc12345_1000000000001"
+    run_id_2 = "2026_05_20_abc12345_1000000000002"
+    write_runner_snapshots(scored, _DATE_STR, _DATE_TAG, run_id=run_id_1, snapshot_dir=tmp_path)
+    write_runner_snapshots(scored, _DATE_STR, _DATE_TAG, run_id=run_id_2, snapshot_dir=tmp_path)
+    file1 = tmp_path / f"runner_snapshots_{_DATE_TAG}_{run_id_1}.jsonl"
+    file2 = tmp_path / f"runner_snapshots_{_DATE_TAG}_{run_id_2}.jsonl"
+    assert file1.exists(), "First run file missing"
+    assert file2.exists(), "Second run file missing"
+    assert file1 != file2
+
+
+def test_supabase_rows_contain_run_id(tmp_path):
+    mock_client = MagicMock()
+    write_runner_snapshots(
+        _scored_1race_2runners(), _DATE_STR, _DATE_TAG, run_id=_RUN_ID,
+        snapshot_dir=tmp_path,
+        supabase_client=mock_client,
+    )
+    call_args = mock_client.table.return_value.insert.call_args
+    assert call_args is not None, "Supabase insert was not called"
+    passed_rows = call_args[0][0]
+    for row in passed_rows:
+        assert row["run_id"] == _RUN_ID, f"row missing run_id: {row.get('run_id')}"
 
 
 # ── Rank and prob_gap ──────────────────────────────────────────────────────────
 
 
 def test_rank_0_is_top_pick(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     rank0 = next(r for r in rows if r["rank"] == 0)
     assert rank0["horse"] == "Horse A"
 
 
 def test_rank_1_is_second_runner(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     rank1 = next(r for r in rows if r["rank"] == 1)
     assert rank1["horse"] == "Horse B"
 
 
 def test_prob_gap_zero_for_rank_0(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     rank0 = next(r for r in rows if r["rank"] == 0)
     assert rank0["prob_gap"] == 0.0
 
 
 def test_prob_gap_correct_for_rank_1(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     rank1 = next(r for r in rows if r["rank"] == 1)
     # top_vp=0.45, runner_vp=0.30 → gap=0.15
     assert abs(rank1["prob_gap"] - 0.15) < 1e-5
@@ -155,11 +219,10 @@ def test_prob_gap_correct_for_rank_1(tmp_path):
 
 
 def test_required_context_fields_present(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     required = {
-        "created_at", "race_date", "race_id", "course", "off_time", "tier",
+        "run_id", "created_at", "race_date", "race_id", "course", "off_time", "tier",
         "rank", "horse", "horse_id", "velo_prime_prob", "market_deception_score",
         "improvement_score", "top_pick_name", "top_pick_vp", "prob_gap",
         "live_scoring_changed", "write_execution_allowed",
@@ -173,17 +236,15 @@ def test_required_context_fields_present(tmp_path):
 
 
 def test_live_scoring_changed_always_false(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     for row in rows:
         assert row["live_scoring_changed"] is False
 
 
 def test_write_execution_allowed_always_false(tmp_path):
-    scored = _scored_1race_2runners()
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(_scored_1race_2runners(), tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     for row in rows:
         assert row["write_execution_allowed"] is False
 
@@ -194,7 +255,8 @@ def test_write_execution_allowed_always_false(tmp_path):
 def test_unwritable_dir_does_not_raise():
     scored = _scored_1race_2runners()
     result = write_runner_snapshots(
-        scored, "2026-05-20", "2026_05_20", snapshot_dir=Path("/dev/null/nonexistent")
+        scored, _DATE_STR, _DATE_TAG, run_id=_RUN_ID,
+        snapshot_dir=Path("/dev/null/nonexistent"),
     )
     assert result == 0
 
@@ -202,9 +264,8 @@ def test_unwritable_dir_does_not_raise():
 def test_supabase_failure_does_not_raise(tmp_path):
     bad_client = MagicMock()
     bad_client.table.return_value.insert.return_value.execute.side_effect = RuntimeError("DB down")
-    scored = _scored_1race_2runners()
     n = write_runner_snapshots(
-        scored, "2026-05-20", "2026_05_20",
+        _scored_1race_2runners(), _DATE_STR, _DATE_TAG, run_id=_RUN_ID,
         snapshot_dir=tmp_path,
         supabase_client=bad_client,
     )
@@ -212,13 +273,14 @@ def test_supabase_failure_does_not_raise(tmp_path):
 
 
 def test_empty_preds_race_is_skipped_gracefully(tmp_path):
-    scored = [(_race(), [], "B", [])]
-    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    n = write_runner_snapshots(
+        [(_race(), [], "B", [])], _DATE_STR, _DATE_TAG, run_id=_RUN_ID, snapshot_dir=tmp_path
+    )
     assert n == 0
 
 
 def test_empty_scored_list_returns_zero(tmp_path):
-    n = write_runner_snapshots([], "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    n = write_runner_snapshots([], _DATE_STR, _DATE_TAG, run_id=_RUN_ID, snapshot_dir=tmp_path)
     assert n == 0
 
 
@@ -228,24 +290,46 @@ def test_empty_scored_list_returns_zero(tmp_path):
 def test_race_context_fields_written_to_all_rows(tmp_path):
     race = _race(race_id="rac_specific", course="Cheltenham", off_time="16:45")
     scored = [(race, [_pred("X"), _pred("Y")], "A", [])]
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    _write(scored, tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     for row in rows:
         assert row["race_id"] == "rac_specific"
         assert row["course"] == "Cheltenham"
         assert row["off_time"] == "16:45"
-        assert row["race_date"] == "2026-05-20"
+        assert row["race_date"] == _DATE_STR
         assert row["tier"] == "A"
 
 
 def test_top_pick_name_written_to_all_rows(tmp_path):
-    race = _race()
-    scored = [(race, [_pred("Top Horse", velo_prime_prob=0.50), _pred("Second Horse", velo_prime_prob=0.25)], "A", [])]
-    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
-    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    scored = [(_race(), [_pred("Top Horse", velo_prime_prob=0.50), _pred("Second Horse", velo_prime_prob=0.25)], "A", [])]
+    _write(scored, tmp_path)
+    rows = _read_rows(tmp_path / _JSONL_NAME)
     for row in rows:
         assert row["top_pick_name"] == "Top Horse"
         assert abs(row["top_pick_vp"] - 0.50) < 1e-6
+
+
+# ── build_run_id ──────────────────────────────────────────────────────────────
+
+
+def test_build_run_id_format():
+    rid = build_run_id("2026_05_20", "abc1234567")
+    parts = rid.split("_")
+    # date_tag has 3 parts joined by underscore: 2026, 05, 20 → then sha8, then epoch_ms
+    assert parts[0] == "2026"
+    assert parts[1] == "05"
+    assert parts[2] == "20"
+    assert parts[3] == "abc12345"  # sha8
+    assert parts[4].isdigit()      # epoch_ms
+
+
+def test_build_run_id_different_calls_produce_different_ids():
+    rid1 = build_run_id("2026_05_20", "abc123")
+    rid2 = build_run_id("2026_05_20", "abc123")
+    # epoch_ms differs between calls (at ms resolution — practically always unique)
+    # Both should at minimum be valid strings with sha component
+    assert "abc123" in rid1
+    assert "abc123" in rid2
 
 
 # ── Supabase happy path ────────────────────────────────────────────────────────
@@ -255,9 +339,9 @@ def test_supabase_called_when_client_provided(tmp_path):
     mock_client = MagicMock()
     mock_execute = MagicMock()
     mock_client.table.return_value.insert.return_value.execute = mock_execute
-    scored = _scored_1race_2runners()
+    _write(_scored_1race_2runners(), tmp_path, run_id=_RUN_ID)
     write_runner_snapshots(
-        scored, "2026-05-20", "2026_05_20",
+        _scored_1race_2runners(), _DATE_STR, _DATE_TAG, run_id=_RUN_ID,
         snapshot_dir=tmp_path,
         supabase_client=mock_client,
     )
@@ -266,6 +350,5 @@ def test_supabase_called_when_client_provided(tmp_path):
 
 
 def test_supabase_not_called_when_no_client(tmp_path):
-    scored = _scored_1race_2runners()
-    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    n = _write(_scored_1race_2runners(), tmp_path)
     assert n == 2

--- a/tests/test_runner_snapshot_store.py
+++ b/tests/test_runner_snapshot_store.py
@@ -1,0 +1,271 @@
+"""
+Tests for Issue #80 — VÉLØ Runner Snapshot Store.
+
+Validates:
+  - JSONL file created with correct row count per runner
+  - All required fields present in each row
+  - Rank 0 = top pick, rank N = Nth runner
+  - prob_gap = 0.0 for rank 0, top_vp - runner_vp for rank > 0
+  - live_scoring_changed and write_execution_allowed always False
+  - Write failure does NOT raise into caller (safety invariant)
+  - Supabase client failure does NOT raise into caller
+  - Empty preds list is handled gracefully
+  - Multiple races written as flat JSONL (one line per runner)
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.velo.runner_snapshot_store import write_runner_snapshots  # noqa: E402
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _pred(horse="Horse A", velo_prime_prob=0.40, mds=0.15, imp=0.12):
+    return {
+        "horse": horse,
+        "horse_id": f"hid_{horse.replace(' ', '_').lower()}",
+        "velo_prime_prob": velo_prime_prob,
+        "sqpe_v17_prob": 0.35,
+        "market_deception_score": mds,
+        "improvement_score": imp,
+        "place_prob": 0.65,
+        "longshot_prob": 0.02,
+        "release_day_prob": 0.10,
+        "comment_intel_score": 0.08,
+        "cash_run_flag": False,
+        "setup_run_flag": False,
+        "decoy_support_flag": False,
+        "rpd_tag": "CYCLE_RUN",
+        "rpd_confidence": 0.70,
+        "rpd_evidence_codes": ["FORM_UP", "MARK_READY"],
+        "rpdc_primary_tag": "STABLE_WARM",
+        "rpdc_release_score": 0.55,
+        "rpdc_cash_window_flag": False,
+        "rpdc_tags": [],
+        "tie_gate_fires": False,
+        "tie_gate_tier_upgrade": None,
+        "active_components": ["sqpe", "mds", "improvement"],
+        "excluded_from_ensemble": [],
+        "assigned_product": "WIN_ONLY",
+        "confidence_level": "HIGH",
+        "decision_tier": "A",
+        "execution_allowed": False,
+        "race_archetype": "Structure",
+        "archetype_confidence": "high",
+        "router_reasons": ["VP_ABOVE_GATE"],
+        "sp_dec": None,
+        "is_fav": None,
+    }
+
+
+def _race(race_id="rac_001", course="Ascot", off_time="14:30"):
+    return {
+        "race_id": race_id,
+        "course": course,
+        "off_time": off_time,
+        "race_name": "Test Race",
+    }
+
+
+def _scored_1race_2runners():
+    race = _race()
+    preds = [
+        _pred("Horse A", velo_prime_prob=0.45),
+        _pred("Horse B", velo_prime_prob=0.30),
+    ]
+    return [(race, preds, "A", [])]
+
+
+def _read_rows(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+# ── Row count and file creation ────────────────────────────────────────────────
+
+
+def test_creates_jsonl_file(tmp_path):
+    scored = _scored_1race_2runners()
+    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    assert n == 2
+    assert (tmp_path / "runner_snapshots_2026_05_20.jsonl").exists()
+
+
+def test_row_count_matches_total_runners(tmp_path):
+    race1 = _race("rac_001")
+    race2 = _race("rac_002", course="Newmarket", off_time="15:00")
+    scored = [
+        (race1, [_pred("A1"), _pred("A2"), _pred("A3")], "A", []),
+        (race2, [_pred("B1"), _pred("B2")], "B", []),
+    ]
+    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    assert n == 5
+    assert len((tmp_path / "runner_snapshots_2026_05_20.jsonl").read_text().splitlines()) == 5
+
+
+def test_each_line_is_valid_json(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    for line in (tmp_path / "runner_snapshots_2026_05_20.jsonl").read_text().splitlines():
+        assert isinstance(json.loads(line), dict)
+
+
+# ── Rank and prob_gap ──────────────────────────────────────────────────────────
+
+
+def test_rank_0_is_top_pick(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    rank0 = next(r for r in rows if r["rank"] == 0)
+    assert rank0["horse"] == "Horse A"
+
+
+def test_rank_1_is_second_runner(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    rank1 = next(r for r in rows if r["rank"] == 1)
+    assert rank1["horse"] == "Horse B"
+
+
+def test_prob_gap_zero_for_rank_0(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    rank0 = next(r for r in rows if r["rank"] == 0)
+    assert rank0["prob_gap"] == 0.0
+
+
+def test_prob_gap_correct_for_rank_1(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    rank1 = next(r for r in rows if r["rank"] == 1)
+    # top_vp=0.45, runner_vp=0.30 → gap=0.15
+    assert abs(rank1["prob_gap"] - 0.15) < 1e-5
+
+
+# ── Required fields ────────────────────────────────────────────────────────────
+
+
+def test_required_context_fields_present(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    required = {
+        "created_at", "race_date", "race_id", "course", "off_time", "tier",
+        "rank", "horse", "horse_id", "velo_prime_prob", "market_deception_score",
+        "improvement_score", "top_pick_name", "top_pick_vp", "prob_gap",
+        "live_scoring_changed", "write_execution_allowed",
+    }
+    for row in rows:
+        for field in required:
+            assert field in row, f"Missing field: {field}"
+
+
+# ── Safety invariants ─────────────────────────────────────────────────────────
+
+
+def test_live_scoring_changed_always_false(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    for row in rows:
+        assert row["live_scoring_changed"] is False
+
+
+def test_write_execution_allowed_always_false(tmp_path):
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    for row in rows:
+        assert row["write_execution_allowed"] is False
+
+
+# ── Failure safety (write failure cannot affect caller) ───────────────────────
+
+
+def test_unwritable_dir_does_not_raise():
+    scored = _scored_1race_2runners()
+    result = write_runner_snapshots(
+        scored, "2026-05-20", "2026_05_20", snapshot_dir=Path("/dev/null/nonexistent")
+    )
+    assert result == 0
+
+
+def test_supabase_failure_does_not_raise(tmp_path):
+    bad_client = MagicMock()
+    bad_client.table.return_value.insert.return_value.execute.side_effect = RuntimeError("DB down")
+    scored = _scored_1race_2runners()
+    n = write_runner_snapshots(
+        scored, "2026-05-20", "2026_05_20",
+        snapshot_dir=tmp_path,
+        supabase_client=bad_client,
+    )
+    assert n == 2
+
+
+def test_empty_preds_race_is_skipped_gracefully(tmp_path):
+    scored = [(_race(), [], "B", [])]
+    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    assert n == 0
+
+
+def test_empty_scored_list_returns_zero(tmp_path):
+    n = write_runner_snapshots([], "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    assert n == 0
+
+
+# ── Race context propagated correctly ─────────────────────────────────────────
+
+
+def test_race_context_fields_written_to_all_rows(tmp_path):
+    race = _race(race_id="rac_specific", course="Cheltenham", off_time="16:45")
+    scored = [(race, [_pred("X"), _pred("Y")], "A", [])]
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    for row in rows:
+        assert row["race_id"] == "rac_specific"
+        assert row["course"] == "Cheltenham"
+        assert row["off_time"] == "16:45"
+        assert row["race_date"] == "2026-05-20"
+        assert row["tier"] == "A"
+
+
+def test_top_pick_name_written_to_all_rows(tmp_path):
+    race = _race()
+    scored = [(race, [_pred("Top Horse", velo_prime_prob=0.50), _pred("Second Horse", velo_prime_prob=0.25)], "A", [])]
+    write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    rows = _read_rows(tmp_path / "runner_snapshots_2026_05_20.jsonl")
+    for row in rows:
+        assert row["top_pick_name"] == "Top Horse"
+        assert abs(row["top_pick_vp"] - 0.50) < 1e-6
+
+
+# ── Supabase happy path ────────────────────────────────────────────────────────
+
+
+def test_supabase_called_when_client_provided(tmp_path):
+    mock_client = MagicMock()
+    mock_execute = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute = mock_execute
+    scored = _scored_1race_2runners()
+    write_runner_snapshots(
+        scored, "2026-05-20", "2026_05_20",
+        snapshot_dir=tmp_path,
+        supabase_client=mock_client,
+    )
+    mock_client.table.assert_called_once_with("runner_prediction_snapshots")
+    mock_execute.assert_called_once()
+
+
+def test_supabase_not_called_when_no_client(tmp_path):
+    scored = _scored_1race_2runners()
+    n = write_runner_snapshots(scored, "2026-05-20", "2026_05_20", snapshot_dir=tmp_path)
+    assert n == 2


### PR DESCRIPTION
## Summary

- **`src/velo/runner_snapshot_store.py`**: new module — batch-writes all scored runners per race to `data/runner_snapshots_YYYY_MM_DD.jsonl` (primary) and Supabase `runner_prediction_snapshots` (best-effort, graceful fallback if table absent)
- **`migrations/create_runner_prediction_snapshots.sql`**: Supabase DDL with indexes for Mid-Price Hunter Phase 2 delta queries and Sigma date-range queries
- **`tests/test_runner_snapshot_store.py`**: 18 tests — row count, rank/prob_gap correctness, required fields, safety invariants, failure isolation
- **`scripts/ops/run_prime_today.py`**: batch write wired at STEP 6 (after local JSON backup, before timing audit) — zero hot-path impact

## Safety invariants
- `live_scoring_changed = False` on every row, always
- `write_execution_allowed = False` on every row, always
- Any write failure logs a warning and returns 0 — never raises into the scoring pipeline
- Module is storage-only: no imports from scoring, routing, or execution paths

## Test results
```
41 passed (23 midprice_hunter + 18 runner_snapshot_store)
ruff: clean
```

## Enables
- Mid-Price Hunter Phase 2: `winner_mds − top_mds` delta analysis (blocked until Issue #80 accumulates data)
- Sigma enrichment: full-field runner context per race instead of top-pick only

## Run migration before next Railway deploy
```sql
-- In Supabase SQL Editor:
-- paste contents of migrations/create_runner_prediction_snapshots.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)