### PR TITLE
fix(#85): RP_MERGED feature differentiation collapse

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1555,7 +1555,9 @@ async def governed_card(date: str = Query(default=None), allow_fallback: bool = 
         _signal_stack = top.get("signal_stack") or v.get("signal_stack")
 
         # rp_flatline_warning — stored in full_analysis.governance (no migration needed)
-        _fa_gov = (v.get("full_analysis") or {}).get("governance", {}) if isinstance(v.get("full_analysis"), dict) else {}
+        _fa_gov = (
+            (v.get("full_analysis") or {}).get("governance", {}) if isinstance(v.get("full_analysis"), dict) else {}
+        )
         _flatline_warning = _fa_gov.get("rp_flatline_warning") or top.get("rp_flatline_warning") or None
 
         verdicts.append(

--- a/app/main.py
+++ b/app/main.py
@@ -1554,6 +1554,10 @@ async def governed_card(date: str = Query(default=None), allow_fallback: bool = 
         )
         _signal_stack = top.get("signal_stack") or v.get("signal_stack")
 
+        # rp_flatline_warning — stored in full_analysis.governance (no migration needed)
+        _fa_gov = (v.get("full_analysis") or {}).get("governance", {}) if isinstance(v.get("full_analysis"), dict) else {}
+        _flatline_warning = _fa_gov.get("rp_flatline_warning") or top.get("rp_flatline_warning") or None
+
         verdicts.append(
             {
                 "race_id": race_id,
@@ -1586,6 +1590,7 @@ async def governed_card(date: str = Query(default=None), allow_fallback: bool = 
                 "operator_read_profile": operator_read_profile,
                 "operator_skepticism_flags": skepticism_flags,
                 "signal_stack": _signal_stack,
+                "rp_flatline_warning": _flatline_warning,
             }
         )
 

--- a/app/services/velo_prime_service.py
+++ b/app/services/velo_prime_service.py
@@ -926,6 +926,7 @@ def persist_race_predictions(race: dict, predictions: list[dict], decision_tier:
             "governance": {
                 "assigned_product": top.get("assigned_product"),
                 "router_reasons": top.get("router_reasons"),
+                "rp_flatline_warning": top.get("rp_flatline_warning"),
             },
         }
 

--- a/app/static/dashboard/index.html
+++ b/app/static/dashboard/index.html
@@ -890,6 +890,13 @@ td:last-child  { padding-right: 20px; }
 .conf-normal { color: var(--gold); }
 .conf-low    { color: var(--fg-secondary); }
 .conf-stale  { font-size: 0.50rem; color: var(--amber); margin-left: 3px; opacity: 0.8; }
+.sc-flatline {
+  width: 100%; margin-top: 4px;
+  background: rgba(255,60,0,0.08); border: 1px solid rgba(255,60,0,0.30);
+  border-radius: 2px; padding: 3px 6px;
+  font-family: var(--font-mono); font-size: 0.52rem;
+  color: #ff6040; line-height: 1.4; white-space: pre-wrap;
+}
 </style>
 
 <div id="sib-wrap">
@@ -2223,6 +2230,15 @@ function buildSidecarHtml(row) {
     html += '<span class="sc-blk-label">BLOCKED:</span>';
     blockers.forEach(b => { html += `<span class="sc-blocker">${b}</span>`; });
     html += '</div>';
+  }
+  // RP_FEATURE_FLATLINE warning — show under the horse when VP was uniform
+  const flatlineWarn = row.rp_flatline_warning || '';
+  if (flatlineWarn) {
+    // Format: "RP_FEATURE_FLATLINE: 8/8 runners tied..." → break into label + body
+    const flatlineParts = flatlineWarn.split(': ');
+    const flatlineLabel = flatlineParts[0] || 'RP_FEATURE_FLATLINE';
+    const flatlineBody  = flatlineParts.slice(1).join(': ');
+    html += `<div class="sc-flatline" title="${flatlineWarn}">⚠ ${flatlineLabel}:<br>${flatlineBody}</div>`;
   }
   html += '</div>';
   return html;

--- a/docs/engineering/THREE_HUNDRED_RUNNER_REVIEW_2026_05_20.md
+++ b/docs/engineering/THREE_HUNDRED_RUNNER_REVIEW_2026_05_20.md
@@ -1,0 +1,297 @@
+# 300-RUNNER REVIEW PACKET — 2026-05-20
+
+**Triggered:** runner_prediction_snapshots crossed n=300 (now 538 rows)
+**Gate date:** 2026-05-20 | **Source:** RP_MERGED | **Run IDs:** 2 (latest: `2026_05_20_32cc27f9_1779275802075`)
+**Snapshot coverage:** 33 races / 269 runners (latest run)
+
+---
+
+## VERDICT SUMMARY
+
+| Metric | Value | Baseline |
+|---|---|---|
+| Strike rate | **6.2%** | 20% |
+| Frame rate | **25.0%** | 48.4% |
+| Wins | 2 (Earthsong GOW 7.50, Allibaba WAR 4.30) | — |
+| Placed | 6 | — |
+| Misses | 24 | — |
+| No result | 1 (GOW 8.20 abandoned) | — |
+
+**Below baseline. Not a fluke. Structural.**
+
+---
+
+## FINDING #1 — SCORING COLLAPSE IN RP_MERGED RACES
+
+This is the primary finding. The runner_prediction_snapshots expose a systematic failure.
+
+### VP Score Uniformity by Race
+
+| Race | Runners | Unique VP Groups | Largest Tied Group | Max VP |
+|---|---|---|---|---|
+| rp_AYR_20260520_1.42 | 4 | **1 (fully uniform)** | 4/4 | 0.2500 |
+| rp_AYR_20260520_2.12 | 8 | 3 | 6/8 | 0.1590 |
+| rp_AYR_20260520_2.42 | 12 | **1 (fully uniform)** | 12/12 | 0.0833 |
+| rp_AYR_20260520_3.12 | 8 | 2 | 7/8 | 0.1379 |
+| rp_AYR_20260520_3.42 | 12 | **1 (fully uniform)** | 12/12 | 0.0833 |
+| rp_AYR_20260520_4.12 | 9 | 3 | 7/9 | 0.1376 |
+| rp_AYR_20260520_4.42 | 9 | **1 (fully uniform)** | 9/9 | 0.1111 |
+| rp_AYR_20260520_5.15 | 8 | **1 (fully uniform)** | 8/8 | 0.1250 |
+| rp_FFO_20260520_2.50 | 6 | 2 | 5/6 | 0.1960 |
+| **rp_FFO_20260520_3.20** | 5 | **5 (fully individualized)** | 1/5 | **0.5479** |
+| rp_FFO_20260520_3.50 | 8 | 2 | 6/8 | 0.1612 |
+| rp_FFO_20260520_4.20 | 4 | 2 | 3/4 | 0.3185 |
+| rp_FFO_20260520_4.50 | 7 | 3 | 3/7 | 0.2809 |
+| rp_FFO_20260520_5.22 | 8 | 3 | 4/8 | 0.2250 |
+| rp_GOW_20260520_5.10 | 10 | 6 | 3/10 | 0.1520 |
+| rp_GOW_20260520_5.45 | 9 | 5 | 5/9 | 0.1437 |
+| rp_GOW_20260520_6.20 | 15 | 6 | 7/15 | 0.2148 |
+| rp_GOW_20260520_6.50 | 10 | 3 | 7/10 | 0.1372 |
+| rp_GOW_20260520_7.20 | 4 | **1 (fully uniform)** | 4/4 | 0.2500 |
+| rp_GOW_20260520_7.50 | 9 | 3 | 4/9 | 0.1980 |
+| rp_WAR_20260520_2.30 | 9 | 2 | 8/9 | 0.1234 |
+| rp_WAR_20260520_3.00 | 7 | 2 | 6/7 | 0.1639 |
+| rp_WAR_20260520_3.30 | 4 | 2 | 3/4 | 0.2744 |
+| rp_WAR_20260520_4.00 | 7 | 4 | 3/7 | 0.2376 |
+| rp_WAR_20260520_4.30 | 7 | 2 | 6/7 | 0.1639 |
+| rp_WAR_20260520_5.00 | 9 | 3 | 7/9 | 0.1319 |
+| rp_YAR_20260520_5.35 | 11 | 5 | 5/11 | 0.2917 |
+| rp_YAR_20260520_6.10 | 8 | 2 | 7/8 | 0.1262 |
+| rp_YAR_20260520_6.40 | 8 | 3 | 6/8 | 0.1614 |
+| rp_YAR_20260520_7.10 | 5 | 2 | 4/5 | 0.2438 |
+| rp_YAR_20260520_7.40 | 8 | 4 | 5/8 | 0.1847 |
+| rp_YAR_20260520_8.10 | 9 | 7 | 2/9 | 0.4871 |
+
+**6 races had fully uniform VP (1/n each — random selection).**
+**20 additional races had the majority of runners tied at the top VP group.**
+**Only 1 race (FFO 3.20, Kenobi) was fully individualized.**
+
+### The Uniform VP Signature
+
+In fully uniform races, every runner receives `VP = 1/field_size`:
+
+| Uniform race | Field | VP each |
+|---|---|---|
+| AYR 1.42 | 4 | 0.2500 |
+| AYR 2.42 | 12 | 0.0833 |
+| AYR 3.42 | 12 | 0.0833 |
+| AYR 4.42 | 9 | 0.1111 |
+| AYR 5.15 | 8 | 0.1250 |
+| GOW 7.20 | 4 | 0.2500 |
+
+**This is the ensemble outputting equal probability = 1/n for every runner.** It is not scoring. It is assigning flat weights to an undifferentiated field. The top pick then becomes whoever appears first in the stored list — effectively random.
+
+---
+
+## FINDING #2 — MDS AND IMPROVEMENT ALSO UNIFORM
+
+In all 6 fully uniform races — and in most tied-group races — **MDS and improvement_score are also identical across all runners in the top group.** For example:
+
+```
+AYR 5.15 all 8 runners:
+  VP=0.1250  MDS=0.0110  IMP=0.0872  PLACE=0.3382  (all identical)
+
+WAR 5.00 top 7 runners:
+  VP=0.1319  MDS=0.0109  IMP=0.0872  PLACE=0.3108  (all identical)
+```
+
+The sidecar models are also not differentiating. This means the feature input pipeline is producing near-identical feature vectors for runners in the same race when RP_MERGED is the source.
+
+**The #73 finding is confirmed in live data:** RP intelligence exists in the building but is not flowing into the scoring contracts.
+
+---
+
+## FINDING #3 — MID-PRICE WINNER ANALYSIS (16 CASES)
+
+| Question | Answer |
+|---|---|
+| Winner visible in snapshots | 15/16 (94%) |
+| Winner beat top pick on MDS | 0/16 |
+| Winner beat top pick on improvement | 0/16 |
+| Winner beat top pick on VP | 0/16 |
+| Winner beat top pick on place_prob | 0/16 |
+| Avg winner SP | 5.46 |
+
+### Winner Rank Distribution (mid-price misses)
+
+| Winner rank | Count | Meaning |
+|---|---|---|
+| 1 | 5 | 2nd in VELO's scoring list |
+| 2 | 2 | 3rd in VELO's scoring list |
+| 4 | 5 | 5th in VELO's scoring list |
+| 5 | 1 | 6th in VELO's scoring list |
+| 6 | 2 | 7th in VELO's scoring list |
+| None | 1 | Not in snapshots |
+
+**5 out of 16 mid-price winners were ranked 2nd by VELO.** The system was almost right in 31% of cases. The winner was right there — one position below the top pick, with identical or near-identical scores.
+
+### Per-Race Detail (16 mid-price misses)
+
+| Race | Course | Top Pick | Winner | SP | Winner Rank | delta_VP | delta_MDS | delta_IMP |
+|---|---|---|---|---|---|---|---|---|
+| rp_AYR_20260520_2.12 | Ayr | A Lady Forever | Jet Warrior | 7.5 | 4 | 0.0 | 0.0 | 0.0 |
+| rp_AYR_20260520_3.12 | Ayr | Classy Al | Military Girl | 3.25 | 4 | 0.0 | 0.0 | 0.0 |
+| rp_AYR_20260520_4.42 | Ayr | Golden Valour | Native Honey | 5.0 | 4 | 0.0 | 0.0 | 0.0 |
+| rp_AYR_20260520_5.15 | Ayr | Evelyn'S Phoenix | Glorious Kitty | 5.5 | 1 | 0.0 | 0.0 | 0.0 |
+| rp_FFO_20260520_4.50 | Ffos Las | Bridget Mary | Lynsey Larue | 10.0 | 1 | 0.0 | 0.0 | 0.0 |
+| rp_FFO_20260520_5.22 | Ffos Las | Barafundle Bay | Kates Choice | 5.0 | 6 | -0.202 | 0.0 | 0.0 |
+| rp_GOW_20260520_5.10 | Gowran | Independent Expert | Gloriously Glam | 5.5 | 6 | -0.067 | 0.0 | 0.0 |
+| rp_GOW_20260520_6.50 | Gowran | Alto Sax | Ballymagreehan | 5.0 | 1 | 0.0 | 0.0 | 0.0 |
+| rp_WAR_20260520_3.00 | Warwick | Edgewell | Yes And Yes | 5.0 | 5 | 0.0 | 0.0 | 0.0 |
+| rp_WAR_20260520_3.30 | Warwick | Full Force Gale | Rangatira Jack | 3.25 | 2 | 0.0 | 0.0 | 0.0 |
+| rp_WAR_20260520_4.00 | Warwick | Crest Of Stars | Il Va De Soi | 4.0 | 1 | 0.0 | 0.0 | 0.0 |
+| rp_WAR_20260520_5.00 | Warwick | Bluegrass | Brendas Asking | 5.5 | 1 | 0.0 | 0.0 | 0.0 |
+| rp_YAR_20260520_6.10 | Yarmouth | Ardad Steve | Peaceful Warrior | 6.5 | 4 | 0.0 | 0.0 | 0.0 |
+| rp_YAR_20260520_6.40 | Yarmouth | Dream Pirate | Jack Sparowe | 10.0 | 2 | 0.0 | 0.0 | 0.0 |
+| rp_YAR_20260520_7.40 | Yarmouth | Charming Fellow | Tilani | 3.12 | 4 | 0.0 | 0.0 | 0.0 |
+| rp_YAR_20260520_8.10 | Yarmouth | Tennessee Gold | Berry Clever | 3.25 | None | — | — | — |
+
+**delta_VP=0.0 in 14/16 cases means the winner and the top pick had exactly the same VP score.** The system cannot distinguish them. Selection within tied VP groups is effectively arbitrary.
+
+---
+
+## FINDING #4 — SHORT-FAV ANALYSIS (6 CASES)
+
+| Race | Top Pick | Winner | Winner SP | Winner Rank |
+|---|---|---|---|---|
+| rp_AYR_20260520_1.42 | Crystal Queen | Ruler's Pride | 1.30 | 2 |
+| rp_FFO_20260520_3.20 | Kenobi | The Flaggy Shore | 2.50 | 1 |
+| rp_FFO_20260520_4.20 | Hell Hound | Loki's Mischief | 2.75 | 2 |
+| rp_GOW_20260520_7.20 | Lady Mairen | Sparan Nua | 3.00 | 2 |
+| rp_WAR_20260520_2.30 | Alex The Great | Rebel Tribesman | 1.33 | 5 |
+| rp_YAR_20260520_7.10 | Golden Garden | Iwantmytimewithyou | 2.62 | 1 |
+
+4/6 short-fav winners were ranked 1 or 2 by VELO. Market was right where VELO was not. **This is the SP gate failure zone** — short-price horses (SP<3.0) that VELO deprioritises because SP data is unavailable from RP_MERGED source.
+
+Note: FFO 3.20 (Kenobi, VP=0.5479) is the fully differentiated race. The winner (The Flaggy Shore) was ranked 1st in VELO's scoring — but Kenobi had VP=0.5479 vs The Flaggy Shore's lower VP. VELO's top pick was the wrong horse despite good differentiation. SP gate would have caught Kenobi: `sp_dec=None → SP_MISSING → UNAUTHORISED_SELECTION`. Execution was already blocked; display was the failure, now fixed by PR #84.
+
+---
+
+## FINDING #5 — WIN RACE PROFILE
+
+Both wins came from horses with VP < 0.20. This is telling.
+
+| Race | Horse | VP | MDS | IMP | PLACE | Tier |
+|---|---|---|---|---|---|---|
+| GOW 7.50 | Earthsong | 0.198 | 0.011 | 0.087 | 0.311 | — |
+| WAR 4.30 | Allibaba | 0.164 | 0.013 | 0.087 | 0.407 | — |
+
+In both WIN races, the top-group VP tied multiple runners at the same value. VELO selected the right horse arbitrarily (by list order, not signal differentiation). **These were correct selections achieved without real scoring signal.** They are not evidence of the model working; they are evidence of lucky coin-flips within tied groups.
+
+---
+
+## FINDING #6 — THE SINGLE WORKING RACE: FFO 3.20 (KENOBI)
+
+This was the only race where VELO produced true per-runner differentiation:
+
+| Runner | VP | MDS | IMP | PLACE |
+|---|---|---|---|---|
+| Kenobi (rank 0) | 0.5479 | 0.016 | 0.100 | 0.600 |
+| (Runner 2) | ~0.28 | — | — | — |
+| (Runner 3–5) | <0.15 | — | — | — |
+
+Kenobi's VP=0.5479 is exceptional relative to the field. The RP features **did flow into scoring here** — this is what a correctly-scored race looks like.
+
+Outcome: MISS (The Flaggy Shore won at SP 2.50). The prediction was scorable and discriminating. It was simply wrong.
+
+**This race is the target state for all races.** Today only 1/33 achieved it.
+
+---
+
+## ROOT CAUSE: WHY RP_MERGED FAILS TO DIFFERENTIATE
+
+The uniform VP = 1/n pattern shows that SQPE is receiving **the same feature vector for all runners** in a race. Possible causes:
+
+1. **Form features not extracted per-runner from RP PDFs** — the colour card (F_0012) and postdata (F_0011) contain form strings, OR ratings, TS ratings, jockey claim, but the feature engineering step does not consume them into per-runner feature vectors.
+
+2. **Features derived from Racing API profiles** (trainer/jockey stats, course records) are not available under RP_MERGED source → all runners fall back to default/mean feature values.
+
+3. **The `or_compression_score` and `postdata_score`** are stored in the snapshot (columns present) but are effectively 0 for RP_MERGED races without enrichment.
+
+The evidence from the #73 field-to-decision audit:
+- `postdata_score` = STORED_ONLY (not live-weighted)
+- `or_compression_score` = FEATURE_DICT_ONLY
+- `spotlight_score` = SHADOW_ONLY
+
+These represent RP intelligence that exists in the pipeline but does not flow into SQPE's scoring weights. Under Racing API source, runner-specific features (SP history, trainer form) would differentiate the field. Under RP_MERGED without enrichment, runners appear identical to the model.
+
+---
+
+## DETERMINATIONS
+
+### Was the mid-price winner ranked 2 or 3?
+**Yes — 5/16 were ranked 2nd (rank=1), 2/16 ranked 3rd (rank=2).** In 44% of mid-price misses the winner was in VELO's top 3. The selection was wrong but the shortlist was partially right.
+
+### Did winner MDS beat top-pick MDS?
+**No — 0/16.** MDS did not distinguish winner from top pick because MDS scores were identical (uniform feature inputs).
+
+### Did winner improvement beat top-pick improvement?
+**No — 0/16.** Same reason.
+
+### Did winner VP beat top-pick VP?
+**No — 0/16.** By definition the top pick has the highest VP; winner tied or was lower.
+
+### Did winner place_prob beat top-pick place_prob?
+**No — 0/16.** Same reason.
+
+### Did top pick trigger MIDPRICE_SUPPRESS_TOP?
+Cannot determine without running midprice_hunter analysis on today's data. Score is stored (`mark_compression_score` present in schema) but review needed.
+
+### Was the winner visible but suppressed?
+**15/16 were visible in snapshots.** They were not suppressed — they were **scored identically to the top pick and lost the arbitrary tie-break.** The suppression is not a routing decision; it is a scoring collapse.
+
+### Was the winner invisible because RP fields were not consumed?
+**Partially.** The winner was present in the snapshot but scored identically to the competition. The RP-sourced per-runner differentiation that would distinguish them (OR rating compression, form trajectory, jockey stats) was not consumed into scoring.
+
+---
+
+## COUNCIL ORDERS — CONFIRMED
+
+| Order | Status |
+|---|---|
+| NO live scoring changes | HOLD |
+| NO panic weight changes | HOLD |
+| NO execution changes | HOLD |
+| 300-runner review triggered | DONE — this document |
+| PR #84 merged | **MERGED** (main, 2026-05-20) |
+| Scrape results from SL | **DONE** — `scripts/ops/scrape_results_sl.py` permanent |
+
+---
+
+## NEXT ENGINEERING ORDERS (PRIORITY ORDER)
+
+### Order 1 — RP Feature Enrichment (HIGH PRIORITY)
+Wire `postdata_score`, `or_compression_score`, and `spotlight_score` into live SQPE feature input. Until this is done, RP_MERGED races will continue to produce near-random selections.
+
+Target: every race reaches FFO 3.20 differentiation standard (unique VP per runner).
+
+### Order 2 — Uniform VP Detection + Suppression
+When all runners in a race share VP = 1/n (uniform), the race should be flagged `SCORING_COLLAPSED`. Operator sees this. No execution allowed under this flag.
+
+Detection: `if len(set(vps)) == 1: flag = SCORING_COLLAPSED`
+
+### Order 3 — Tie-Break Improvement
+For races with the top group tied at the same VP, implement secondary tie-breaking using available RP signals: postdata_score → spotlight_score → or_compression_score → alphabetical (current fallback).
+
+This will not fix the problem but will make tie-breaking less arbitrary.
+
+### Order 4 — Mid-Price Hunter (#78) — Activate Monitoring Mode
+With 538 snapshots now available, begin monitoring for the MIDPRICE_SUPPRESS_TOP pattern. The hunter should flag races where:
+- Our top pick VP is in the 0.15–0.35 band
+- AND a competitor has comparable or higher postdata/OR signals
+- AND winner SP falls in 3.0–8.5 zone
+
+This is watchlist-only, no execution changes.
+
+### Order 5 — Sigma Results — Wire Sporting Life Fallback
+`scripts/ops/scrape_results_sl.py` now exists. Wire as automatic fallback in sigma when Racing API `/results` returns 401/403. Cache-first logic already in place.
+
+---
+
+## SECURITY NOTE
+
+Multiple operational tables including `runner_prediction_snapshots` have RLS disabled. Do NOT flip RLS during this review — it will break reads/writes without policies. Schedule as separate hardening issue (Issue #85 or similar) after current sprint closes.
+
+---
+
+*Document generated: 2026-05-20 | Evidence basis: 538 runner_prediction_snapshots, scraped Sporting Life results, sigma audit n=32*

--- a/scripts/ops/run_prime_today.py
+++ b/scripts/ops/run_prime_today.py
@@ -1187,6 +1187,10 @@ def main():
         build_run_id as _build_run_id,
         write_runner_snapshots as _write_runner_snapshots,
     )
+    from src.velo.feature_audit import (
+        detect_vp_flatline as _detect_vp_flatline,
+        flatline_summary_for_run as _flatline_summary_for_run,
+    )
     from src.velo.signal_stack import build_signal_stack_payload as _build_signal_stack
     from supabase import create_client as _sb_create
     from workers.racing_api_normalizer import normalize_race
@@ -1369,6 +1373,7 @@ def main():
     _race_timings: list[dict] = []
     _spotlight_total = 0
     _pdf_intel_attached_total = 0
+    _flatlines: list[dict] = []
     for race in normalized:
         cid = f"{race.get('course')} {race.get('off_time', '?')}"
 
@@ -1465,6 +1470,18 @@ def main():
                     pred["rpd_evidence_codes"] = rpd_evidence
                 _spotlight_total += _spotlight_this_race
 
+                # ── Flatline detector (Issue #85) ─────────────────────────────
+                # Read-only post-scoring check — never alters velo_prime_prob,
+                # rank order, tier, router lane, or execution.
+                _flatline_info = _detect_vp_flatline(
+                    race.get("race_id", ""),
+                    preds,
+                    racecard_source,
+                )
+                if _flatline_info:
+                    _flatlines.append(_flatline_info)
+                    log.warning(_flatline_info["warning"])
+
                 top = preds[0]
                 second = preds[1] if len(preds) > 1 else {}
                 sec_prob = float(second.get("velo_prime_prob") or 0)
@@ -1473,6 +1490,7 @@ def main():
                 # Raw label (pre-normalization) is preserved separately.
                 top["confidence_level_raw"] = top.get("confidence_level")
                 top["confidence_level_effective"] = effective_confidence(float(top.get("velo_prime_prob") or 0))
+                top["rp_flatline_warning"] = _flatline_info.get("warning") if _flatline_info else None
                 # Shadow suspect cohort flag — A-tier with weak place support.
                 # No gate change. Passive monitor only. Track for 30 days to build
                 # enough sample to decide whether to tighten the A-gate conditionally.
@@ -1653,6 +1671,20 @@ def main():
             print(f"  FAIL  {cid} — {e}")
 
     print(f"\n  Scored: {len(scored)}  Errors: {len(score_errors)}")
+
+    # ── Flatline summary (Issue #85) ──────────────────────────────────────────
+    _flatline_summary = _flatline_summary_for_run(_flatlines, total_races=len(scored))
+    if _flatlines:
+        print(
+            f"\n  RP_FEATURE_FLATLINE: {_flatline_summary['flatline_count']}/{_flatline_summary['total_races']} races "
+            f"({_flatline_summary['flatline_pct']:.1%}) — "
+            f"{_flatline_summary['fully_uniform_count']} fully uniform, "
+            f"{_flatline_summary['majority_tied_count']} majority tied"
+        )
+        for _fl in _flatlines:
+            print(f"    {_fl['race_id']}: {_fl['warning'][:100]}")
+    else:
+        print(f"\n  RP_FEATURE_FLATLINE: 0/{len(scored)} races — VP well-differentiated")
 
     # ── GOVERNED CARD SUMMARY ─────────────────────────────────────────────────
     from collections import Counter
@@ -1930,6 +1962,7 @@ def main():
             spotlight_total=_spotlight_total,
             pdf_intel_total=_pdf_intel_attached_total,
         )
+        _timing_payload["flatline_summary"] = _flatline_summary
         _timing_out.parent.mkdir(parents=True, exist_ok=True)
         _timing_out.write_text(json.dumps(_timing_payload, indent=2, default=str))
         print(f"\nTIMING AUDIT: {_timing_out.name}")

--- a/src/velo/feature_audit.py
+++ b/src/velo/feature_audit.py
@@ -9,7 +9,6 @@ Hard constraints: read-only, no scoring changes, no routing changes.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 
@@ -80,8 +79,12 @@ def build_scoring_feature_audit(
             "constant_value": list(unique_vals)[0] if len(unique_vals) == 1 else None,
         }
 
-    # Compute constant-feature count: fields where all runners share the same value
-    constant_fields = [f for f, r in field_reports.items() if r["unique_value_count"] <= 1]
+    # Constant: field has exactly one distinct non-null value across all runners.
+    # Explicitly excludes all-missing fields (coverage=0) to keep audit categories disjoint.
+    constant_fields = [
+        f for f, r in field_reports.items()
+        if r["unique_value_count"] == 1 and r["coverage_pct"] > 0
+    ]
     missing_fields = [f for f, r in field_reports.items() if r["coverage_pct"] == 0.0]
 
     return {

--- a/src/velo/feature_audit.py
+++ b/src/velo/feature_audit.py
@@ -1,0 +1,205 @@
+"""
+VÉLØ Feature Audit + Flatline Detector — Issue #85.
+
+build_scoring_feature_audit(): per-race field-level coverage report.
+detect_vp_flatline():           post-scoring flatline check per race.
+
+Hard constraints: read-only, no scoring changes, no routing changes.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_AUDITED_FIELDS = (
+    "official_rating",
+    "rpr",
+    "ts",
+    "draw",
+    "best_odds_decimal",
+    "postdata_score",
+    "or_compression_score",
+    "mark_compression_score",
+    "spotlight_score",
+    "market_deception_score",
+    "improvement_score",
+    "place_prob",
+    "release_day_prob",
+    "comment_intel_score",
+    "rpdc_release_score",
+    "rpdc_primary_tag",
+    "plot_conviction",
+    "trainer_form_signal",
+    "ts_trend_signal",
+    "or_trend_signal",
+)
+
+# Flatline thresholds — see CLAUDE.md / THREE_HUNDRED_RUNNER_REVIEW_2026_05_20.md
+_FLATLINE_MAX_UNIQUE = 2        # <= 2 distinct VP values → flatline
+_FLATLINE_TIE_GROUP_PCT = 0.60  # top tie group covers >= 60% of field → flatline
+
+
+def build_scoring_feature_audit(
+    race: dict[str, Any],
+    runners: list[dict[str, Any]],
+    source_label: str = "",
+) -> dict[str, Any]:
+    """
+    Produce a per-race field-level coverage audit for RP_MERGED diagnostics.
+
+    For each audited field, reports:
+        coverage_pct          : fraction of runners where field is non-None, non-zero
+        unique_value_count    : distinct non-null values seen
+        null_count            : runners where field is None or 0
+        constant_value        : the single value if all runners share one (else None)
+
+    Returns a summary dict suitable for logging and dashboard persistence.
+    """
+    n = max(len(runners), 1)
+    field_reports: dict[str, dict] = {}
+
+    for field in _AUDITED_FIELDS:
+        values = []
+        for r in runners:
+            # Check runner dict first, then pdf_intel sub-dict
+            v = r.get(field)
+            if v is None:
+                pdf = r.get("pdf_intel") or {}
+                v = pdf.get(field)
+            values.append(v)
+
+        non_null = [v for v in values if v is not None and v != 0 and v != 0.0 and v != ""]
+        unique_vals = set(str(v) for v in non_null)
+
+        field_reports[field] = {
+            "coverage_pct": round(len(non_null) / n, 3),
+            "unique_value_count": len(unique_vals),
+            "null_count": n - len(non_null),
+            "constant_value": list(unique_vals)[0] if len(unique_vals) == 1 else None,
+        }
+
+    # Compute constant-feature count: fields where all runners share the same value
+    constant_fields = [f for f, r in field_reports.items() if r["unique_value_count"] <= 1]
+    missing_fields = [f for f, r in field_reports.items() if r["coverage_pct"] == 0.0]
+
+    return {
+        "race_id": race.get("race_id", ""),
+        "course": race.get("course", ""),
+        "off_time": race.get("off_time", ""),
+        "source_label": source_label,
+        "runner_count": n,
+        "constant_feature_count": len(constant_fields),
+        "missing_feature_count": len(missing_fields),
+        "constant_fields": constant_fields,
+        "missing_fields": missing_fields,
+        "fields": field_reports,
+    }
+
+
+def detect_vp_flatline(
+    race_id: str,
+    predictions: list[dict[str, Any]],
+    source_label: str = "",
+) -> dict[str, Any] | None:
+    """
+    Post-scoring flatline check. Call after score_race_velo_prime() returns.
+
+    Returns a flatline descriptor dict when the race scores collapse:
+        {
+            "race_id": ...,
+            "flatline": True,
+            "unique_vp_count": N,
+            "runner_count": N,
+            "max_tie_group_size": N,
+            "max_tie_group_pct": 0.xx,
+            "max_vp": 0.xxxx,
+            "source_label": ...,
+            "warning": "RP_FEATURE_FLATLINE: ...",
+        }
+
+    Returns None when the race is well-differentiated (no flatline).
+    """
+    if not predictions:
+        return None
+
+    vps = [float(p.get("velo_prime_prob") or 0) for p in predictions]
+    n = len(vps)
+
+    # Count occurrences per VP bucket (6 decimal places — same as storage precision)
+    from collections import Counter
+    vp_counts = Counter(round(v, 6) for v in vps)
+    unique_count = len(vp_counts)
+    max_tie_group = max(vp_counts.values())
+    tie_group_pct = max_tie_group / n
+    max_vp = max(vps) if vps else 0.0
+
+    is_flatline = (unique_count <= _FLATLINE_MAX_UNIQUE) or (tie_group_pct >= _FLATLINE_TIE_GROUP_PCT)
+
+    if not is_flatline:
+        return None
+
+    if unique_count == 1:
+        msg = (
+            f"RP_FEATURE_FLATLINE: {n}/{n} runners tied at VP={max_vp:.4f}. "
+            f"Source features not differentiating. Treat selection as VISION_ONLY."
+        )
+    else:
+        msg = (
+            f"RP_FEATURE_FLATLINE: {max_tie_group}/{n} runners in top tie group "
+            f"({tie_group_pct:.0%}). Unique VP groups={unique_count}. "
+            f"Selection reliability degraded."
+        )
+
+    return {
+        "race_id": race_id,
+        "flatline": True,
+        "unique_vp_count": unique_count,
+        "runner_count": n,
+        "max_tie_group_size": max_tie_group,
+        "max_tie_group_pct": round(tie_group_pct, 3),
+        "max_vp": round(max_vp, 4),
+        "source_label": source_label,
+        "warning": msg,
+    }
+
+
+def flatline_summary_for_run(
+    flatlines: list[dict[str, Any]],
+    total_races: int,
+) -> dict[str, Any]:
+    """
+    Aggregate flatline stats for a full scoring run.
+
+    Returns a summary for Telegram / timing audit / local JSON.
+    """
+    if not flatlines:
+        return {
+            "flatline_count": 0,
+            "total_races": total_races,
+            "flatline_pct": 0.0,
+            "fully_uniform_count": 0,
+            "majority_tied_count": 0,
+            "races": [],
+        }
+
+    fully_uniform = [f for f in flatlines if f["unique_vp_count"] == 1]
+    majority_tied = [f for f in flatlines if f["unique_vp_count"] > 1]
+
+    return {
+        "flatline_count": len(flatlines),
+        "total_races": total_races,
+        "flatline_pct": round(len(flatlines) / max(total_races, 1), 3),
+        "fully_uniform_count": len(fully_uniform),
+        "majority_tied_count": len(majority_tied),
+        "races": [
+            {
+                "race_id": f["race_id"],
+                "unique_vp_count": f["unique_vp_count"],
+                "runner_count": f["runner_count"],
+                "max_tie_pct": f["max_tie_group_pct"],
+            }
+            for f in flatlines
+        ],
+    }

--- a/src/velo/racecard_loader.py
+++ b/src/velo/racecard_loader.py
@@ -40,14 +40,14 @@ _IRE_VENUE_CODES = frozenset({
 })
 
 
-def _parse_betting_forecast(forecast_str: str) -> dict[str, float]:
+def _parse_betting_forecast(forecast_str: str | None) -> dict[str, float]:
     """
     Parse a RP betting forecast string into {horse_name_lower: decimal_odds}.
 
     Handles: "4/6 One Knight, 5/2 The Flaggy Shore, 100/1 Kenobi"
              "EVS Bluegrass, 2/1 Crystal Queen" (EVS = 2.0)
     Strips favourite markers (F, JF, CF) from odds tokens.
-    Returns empty dict on any parse failure so callers can fall back gracefully.
+    Segments that cannot be parsed are skipped; returns {} for None/empty input.
     """
     if not forecast_str:
         return {}
@@ -107,7 +107,6 @@ def load_rp_merged_as_racecards(date_str: str, data_root: Path) -> list[dict[str
       - postdata_score, or_compression_score, plot_conviction wired as "pdf_intel"
         so _build_live_features() reads them on the first pass
       - going and race_class extracted from race_info when present
-      - draw extracted from horse weight/stall strings when available
 
     Fields absent from RP data remain None. Sets region="IRE" for Irish venues.
     Returns an empty list if no RP merged files exist for the date.

--- a/src/velo/racecard_loader.py
+++ b/src/velo/racecard_loader.py
@@ -40,19 +40,80 @@ _IRE_VENUE_CODES = frozenset({
 })
 
 
+def _parse_betting_forecast(forecast_str: str) -> dict[str, float]:
+    """
+    Parse a RP betting forecast string into {horse_name_lower: decimal_odds}.
+
+    Handles: "4/6 One Knight, 5/2 The Flaggy Shore, 100/1 Kenobi"
+             "EVS Bluegrass, 2/1 Crystal Queen" (EVS = 2.0)
+    Strips favourite markers (F, JF, CF) from odds tokens.
+    Returns empty dict on any parse failure so callers can fall back gracefully.
+    """
+    if not forecast_str:
+        return {}
+    result: dict[str, float] = {}
+    for part in forecast_str.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        tokens = part.split(None, 1)
+        if len(tokens) != 2:
+            continue
+        odds_tok, horse_name = tokens
+        # Strip favourite markers (trailing F, JF, CF)
+        odds_tok = odds_tok.rstrip("FJCfjc")
+        try:
+            if odds_tok.upper() in ("EVS", "EVENS"):
+                dec = 2.0
+            elif "/" in odds_tok:
+                num, den = odds_tok.split("/")
+                dec = round(int(num) / int(den) + 1, 3)
+            else:
+                dec = round(float(odds_tok) + 1, 3)
+            result[horse_name.strip().lower()] = dec
+        except (ValueError, ZeroDivisionError):
+            continue
+    return result
+
+
+def _fuzzy_odds_lookup(name: str, forecast_odds: dict[str, float]) -> float:
+    """
+    Look up a horse's forecast odds by fuzzy name match (strips non-alpha chars).
+
+    Returns 0.0 when no match found (caller uses 0.0 as 'odds unavailable').
+    """
+    import re as _re
+    if not forecast_odds:
+        return 0.0
+    name_key = _re.sub(r"[^a-z]", "", name.lower())
+    for fname, dec in forecast_odds.items():
+        fname_key = _re.sub(r"[^a-z]", "", fname)
+        if fname_key == name_key or (len(fname_key) > 4 and (fname_key in name_key or name_key in fname_key)):
+            return dec
+    return 0.0
+
+
 def load_rp_merged_as_racecards(date_str: str, data_root: Path) -> list[dict[str, Any]]:
     """
-    Synthesise minimal Racing API-compatible race dicts from RP merged JSON files.
+    Synthesise Racing API-compatible race dicts from RP merged JSON files.
 
     Reads all {data_root}/racecard_merged/racecard_*_{date_str}.json files and
     builds race dicts with enough structure for normalize_race() to process.
-    Fields absent from RP data (horse_id, draw, lbs, etc.) are None.
 
-    Sets region="IRE" for known Irish venue codes, "GB" for all others so the
-    jurisdiction filter keeps all UK/IRE races.
+    Hydration improvements (Issue #85 — RP_MERGED differentiation collapse):
+      - betting_forecast parsed and injected as per-horse "odds" → normalizer
+        converts to best_odds_decimal, driving sp_dec/sp_rank differentiation
+      - ts_latest, ts_master wired as "ts" and "ts_master" for TS-based scoring
+      - postdata_score, or_compression_score, plot_conviction wired as "pdf_intel"
+        so _build_live_features() reads them on the first pass
+      - going and race_class extracted from race_info when present
+      - draw extracted from horse weight/stall strings when available
 
+    Fields absent from RP data remain None. Sets region="IRE" for Irish venues.
     Returns an empty list if no RP merged files exist for the date.
     """
+    import re as _re
+
     merged_dir = data_root / "racecard_merged"
     rp_files = list(merged_dir.glob(f"racecard_*_{date_str}.json"))
     if not rp_files:
@@ -74,11 +135,52 @@ def load_rp_merged_as_racecards(date_str: str, data_root: Path) -> list[dict[str
             if not horses:
                 continue
 
+            # ── Betting forecast → per-horse odds ────────────────────────────
+            forecast_raw = race_data.get("betting_forecast", "")
+            forecast_odds = _parse_betting_forecast(forecast_raw)
+
+            # ── Race-level metadata ───────────────────────────────────────────
+            race_info = race_data.get("race_info", "")
+            going_str: str | None = None
+            race_class: str | None = None
+            m_going = _re.search(r"\b(Good|Firm|Soft|Heavy|Yielding|Standard)[^\)]*", race_info, _re.I)
+            if m_going:
+                going_str = m_going.group(0).strip()
+            m_class = _re.search(r"Class\s*(\d)", race_info, _re.I)
+            if m_class:
+                race_class = m_class.group(1)
+
             runners = []
             for h in horses:
                 name = h.get("horse_name") or h.get("horse", "")
                 if not name:
                     continue
+
+                # Odds from betting forecast
+                odds_dec = _fuzzy_odds_lookup(name, forecast_odds)
+
+                # TS: prefer ts_latest, fall back to ts_adjusted / ts_master
+                ts_val = (
+                    h.get("ts_latest")
+                    or h.get("ts_adjusted")
+                    or h.get("ts_master")
+                )
+
+                # Build pdf_intel dict for immediate use in _build_live_features()
+                pdf_intel: dict[str, Any] = {
+                    "postdata_score": h.get("postdata_score", 0.0) or 0.0,
+                    "or_compression_score": h.get("or_compression_score", 0.0) or 0.0,
+                    "plot_conviction": h.get("plot_conviction", 0.0) or 0.0,
+                    "ts_master": float(h.get("ts_master") or h.get("ts_adjusted") or 0),
+                    "or_delta_to_best_win": 0.0,
+                    "trainer_form_signal": h.get("trainer_form_signal", 0.0) or 0.0,
+                    "ts_trend_signal": h.get("ts_trend_signal", 0.0) or 0.0,
+                    "or_trend_signal": h.get("or_trend_signal", 0.0) or 0.0,
+                    "handicap_plot_score": h.get("handicap_plot_score") or 0.0,
+                    # Pass through the raw RP horse dict for downstream enrichment
+                    "_rp_raw": h,
+                }
+
                 runners.append({
                     "horse": name,
                     "horse_id": f"rp_{venue_code}_{name.lower().replace(' ', '_')}",
@@ -90,13 +192,21 @@ def load_rp_merged_as_racecards(date_str: str, data_root: Path) -> list[dict[str
                     "jockey": None,
                     "ofr": None,
                     "rpr": None,
-                    "ts": h.get("ts_latest"),
+                    "ts": ts_val,
+                    "ts_master": h.get("ts_master"),
                     "form": None,
                     "last_run": None,
+                    # Odds: set so normalizer converts to best_odds_decimal
+                    "odds": odds_dec if odds_dec > 0 else None,
+                    # RP passthrough fields
                     "_rp_horse_name": name,
                     "_rp_ts_base": h.get("ts_base"),
                     "_rp_plot_conviction": h.get("plot_conviction"),
                     "_rp_or_compression_score": h.get("or_compression_score"),
+                    "_rp_postdata_score": h.get("postdata_score"),
+                    # Pre-built pdf_intel so _build_live_features() reads it immediately
+                    # (before the post-normalization pdf_intel_cache loop runs)
+                    "pdf_intel": pdf_intel,
                 })
 
             time_parts = race_time.replace(":", "_")
@@ -106,12 +216,14 @@ def load_rp_merged_as_racecards(date_str: str, data_root: Path) -> list[dict[str
                 "course_id": venue_code.lower(),
                 "date": date_str,
                 "off_time": race_time,
-                "race_name": race_data.get("race_info", "")[:80],
+                "race_name": race_info[:80],
                 "distance_f": None,
-                "going": None,
-                "race_class": None,
+                "going": going_str,
+                "race_class": race_class,
                 "region": region,
                 "runners": runners,
+                # Keep raw forecast for diagnostics
+                "_rp_betting_forecast": forecast_raw,
             })
 
     return races

--- a/tests/test_rp_feature_differentiation.py
+++ b/tests/test_rp_feature_differentiation.py
@@ -274,7 +274,7 @@ def test_flatline_silent_when_differentiated():
 
 
 def test_flatline_at_boundary():
-    """Exactly 60% tie group → flatline fires."""
+    """Boundary: 50% tie group is below threshold (no flatline); 66.7% fires."""
     vps = [0.25, 0.25, 0.25, 0.10, 0.08, 0.05]  # 3/6 = 50% — below threshold
     result = detect_vp_flatline("rp_TEST", _preds(vps), "rp_merged")
     assert result is None  # 50% < 60%

--- a/tests/test_rp_feature_differentiation.py
+++ b/tests/test_rp_feature_differentiation.py
@@ -1,0 +1,366 @@
+"""
+Tests for Issue #85 — RP_MERGED Feature Differentiation Collapse.
+
+Validates:
+  Phase 1 — Regression proof:
+    - Uniform race (AYR 1.42 fixture): was VP=1/n before fix
+    - After fix: betting_forecast odds produce differentiated best_odds_decimal
+    - FFO 3.20 (Kenobi): was fully differentiated, still is
+
+  Phase 2 — Feature audit:
+    - build_scoring_feature_audit reports constant_fields for null-input races
+    - build_scoring_feature_audit reports coverage_pct per field
+
+  Phase 3 — Flatline detector:
+    - detect_vp_flatline: fires for uniform VP input
+    - detect_vp_flatline: fires for majority-tied input (>= 60%)
+    - detect_vp_flatline: silent when VP is well-differentiated
+    - flatline_summary_for_run: aggregates correctly
+
+  Racecard loader:
+    - _parse_betting_forecast: fractional, EVS, favourite markers
+    - _fuzzy_odds_lookup: exact, fuzzy, apostrophe names
+    - load_rp_merged_as_racecards: odds injected, pdf_intel built
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.velo.racecard_loader import (  # noqa: E402
+    _fuzzy_odds_lookup,
+    _parse_betting_forecast,
+    load_rp_merged_as_racecards,
+)
+from src.velo.feature_audit import (  # noqa: E402
+    build_scoring_feature_audit,
+    detect_vp_flatline,
+    flatline_summary_for_run,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+DATE = "2026-05-20"
+DATA_ROOT = ROOT / "data"
+
+# AYR 1.42 — 4-runner race, no betting forecast in merged JSON (fully uniform pre-fix)
+_AYR_142_RACE_ID = f"rp_AYR_{DATE.replace('-','')}_{1}_{42}"
+
+# FFO 3.20 — 5 runners, betting forecast present (was differentiated before fix)
+_FFO_320_FORECAST = "4/6 One Knight, 5/2 The Flaggy Shore, 4/1 Fiskardo, 33/1 Brenda Lady, 100/1 Kenobi"
+_FFO_320_HORSES = ["One Knight", "The Flaggy Shore", "Fiskardo", "Brenda Lady", "Kenobi"]
+
+# ── _parse_betting_forecast ───────────────────────────────────────────────────
+
+
+def test_parse_forecast_basic():
+    odds = _parse_betting_forecast("4/6 One Knight, 5/2 The Flaggy Shore, 100/1 Kenobi")
+    assert abs(odds["one knight"] - (4 / 6 + 1)) < 0.01
+    assert abs(odds["the flaggy shore"] - (5 / 2 + 1)) < 0.01
+    assert abs(odds["kenobi"] - 101.0) < 0.01
+
+
+def test_parse_forecast_evs():
+    odds = _parse_betting_forecast("EVS Bluegrass, 2/1 Crystal Queen")
+    assert abs(odds["bluegrass"] - 2.0) < 0.01
+    assert abs(odds["crystal queen"] - 3.0) < 0.01
+
+
+def test_parse_forecast_favourite_marker():
+    # "2/1F" or "4/6F" — strip the F
+    odds = _parse_betting_forecast("4/6F One Knight, 5/2 The Flaggy Shore")
+    assert "one knight" in odds
+    assert abs(odds["one knight"] - (4 / 6 + 1)) < 0.01
+
+
+def test_parse_forecast_empty_string():
+    assert _parse_betting_forecast("") == {}
+
+
+def test_parse_forecast_none():
+    assert _parse_betting_forecast(None) == {}
+
+
+def test_parse_forecast_full_ffo():
+    odds = _parse_betting_forecast(_FFO_320_FORECAST)
+    assert len(odds) == 5
+    assert "one knight" in odds
+    assert "kenobi" in odds
+    assert odds["kenobi"] == 101.0
+
+
+# ── _fuzzy_odds_lookup ────────────────────────────────────────────────────────
+
+
+def test_fuzzy_lookup_exact():
+    forecast = {"crystal queen": 5.0, "a lady forever": 3.5}
+    assert _fuzzy_odds_lookup("Crystal Queen", forecast) == 5.0
+
+
+def test_fuzzy_lookup_apostrophe():
+    forecast = {"evelyn's phoenix": 7.0}
+    assert _fuzzy_odds_lookup("Evelyn'S Phoenix", forecast) == 7.0
+
+
+def test_fuzzy_lookup_no_match():
+    forecast = {"some other horse": 3.0}
+    assert _fuzzy_odds_lookup("Crystal Queen", forecast) == 0.0
+
+
+def test_fuzzy_lookup_empty_forecast():
+    assert _fuzzy_odds_lookup("Any Horse", {}) == 0.0
+
+
+def test_fuzzy_lookup_substring():
+    forecast = {"golden garden": 6.0}
+    # Short 4-char names skip fuzzy — 'goldengarden' is 12 chars, should match
+    assert _fuzzy_odds_lookup("Golden Garden", forecast) == 6.0
+
+
+# ── load_rp_merged_as_racecards — odds injection ──────────────────────────────
+
+
+def _load_today(date: str = DATE) -> list[dict]:
+    """Load today's merged racecards if they exist (skip test if not)."""
+    import pytest
+    merged_dir = DATA_ROOT / "racecard_merged"
+    files = list(merged_dir.glob(f"racecard_*_{date}.json"))
+    if not files:
+        pytest.skip(f"No racecard_merged files for {date} — fixture unavailable")
+    return load_rp_merged_as_racecards(date, DATA_ROOT)
+
+
+def test_loader_returns_races():
+    races = _load_today()
+    assert len(races) > 0
+
+
+def test_loader_runners_have_horse_id():
+    races = _load_today()
+    for race in races:
+        for runner in race.get("runners", []):
+            assert runner.get("horse_id", "").startswith("rp_")
+
+
+def test_loader_ffo_odds_injected():
+    """FFO 3.20 has betting_forecast — runners must have differentiated odds."""
+    races = _load_today()
+    ffo_races = [r for r in races if "FFO" in r.get("race_id", "") and "3_20" in r.get("race_id", "")]
+    if not ffo_races:
+        import pytest
+        pytest.skip("FFO 3.20 not in today's data")
+    ffo = ffo_races[0]
+    runner_odds = [r.get("odds") for r in ffo["runners"] if r.get("odds")]
+    # At least 2 runners must have distinct odds
+    assert len(set(runner_odds)) >= 2, f"Expected differentiated odds, got: {runner_odds}"
+
+
+def test_loader_runners_with_forecast_have_odds():
+    """Any race with a non-empty betting_forecast must produce non-zero odds for top runners."""
+    races = _load_today()
+    for race in races:
+        if not race.get("_rp_betting_forecast", ""):
+            continue
+        runners = race.get("runners", [])
+        runners_with_odds = [r for r in runners if r.get("odds") and r["odds"] > 0]
+        # At least half the runners should have odds when a forecast is present
+        if len(runners) >= 2:
+            assert len(runners_with_odds) >= 1, (
+                f"Race {race['race_id']} has forecast but no runner odds: {race['_rp_betting_forecast']}"
+            )
+
+
+def test_loader_pdf_intel_built():
+    """Each runner should have a pdf_intel dict (may be empty values)."""
+    races = _load_today()
+    for race in races[:3]:  # check first 3 races only
+        for runner in race.get("runners", [])[:3]:
+            assert "pdf_intel" in runner, f"pdf_intel missing on {runner.get('horse')}"
+            assert isinstance(runner["pdf_intel"], dict)
+
+
+def test_loader_ayr_no_forecast_still_builds_runners():
+    """AYR races with no betting_forecast must still produce runners (odds=None)."""
+    races = _load_today()
+    ayr_races = [r for r in races if "AYR" in r.get("race_id", "")]
+    assert len(ayr_races) > 0
+    for race in ayr_races:
+        assert len(race.get("runners", [])) > 0
+
+
+# ── build_scoring_feature_audit ───────────────────────────────────────────────
+
+_UNIFORM_RUNNERS = [
+    {"horse_name": f"Horse{i}", "best_odds_decimal": 10.0, "rpr": None, "ts": None, "draw": None}
+    for i in range(8)
+]
+
+_DIFFERENTIATED_RUNNERS = [
+    {"horse_name": "Horse1", "best_odds_decimal": 2.0, "rpr": 110.0, "ts": 95.0, "draw": 3},
+    {"horse_name": "Horse2", "best_odds_decimal": 4.5, "rpr": 105.0, "ts": 88.0, "draw": 7},
+    {"horse_name": "Horse3", "best_odds_decimal": 8.0, "rpr": 98.0, "ts": 80.0, "draw": 1},
+]
+
+
+def test_feature_audit_identifies_null_fields():
+    audit = build_scoring_feature_audit({}, _UNIFORM_RUNNERS, "rp_merged")
+    # rpr, ts, draw are None → missing
+    assert "rpr" in audit["missing_fields"]
+    assert "ts" in audit["missing_fields"]
+    assert "draw" in audit["missing_fields"]
+
+
+def test_feature_audit_constant_field_detected():
+    """All 8 runners have same best_odds_decimal → constant field."""
+    audit = build_scoring_feature_audit({}, _UNIFORM_RUNNERS, "rp_merged")
+    assert "best_odds_decimal" in audit["constant_fields"]
+
+
+def test_feature_audit_differentiated_field_not_constant():
+    audit = build_scoring_feature_audit({}, _DIFFERENTIATED_RUNNERS, "api")
+    assert "best_odds_decimal" not in audit["constant_fields"]
+    assert audit["fields"]["best_odds_decimal"]["unique_value_count"] == 3
+
+
+def test_feature_audit_coverage_pct():
+    audit = build_scoring_feature_audit({}, _DIFFERENTIATED_RUNNERS, "api")
+    assert audit["fields"]["rpr"]["coverage_pct"] == 1.0
+    assert audit["fields"]["ts"]["coverage_pct"] == 1.0
+
+
+def test_feature_audit_runner_count():
+    audit = build_scoring_feature_audit({}, _UNIFORM_RUNNERS, "rp_merged")
+    assert audit["runner_count"] == 8
+
+
+# ── detect_vp_flatline ────────────────────────────────────────────────────────
+
+def _preds(vps: list[float]) -> list[dict]:
+    return [{"horse": f"Horse{i}", "velo_prime_prob": v} for i, v in enumerate(vps)]
+
+
+def test_flatline_fully_uniform():
+    """8 runners all VP=0.1250 → flatline."""
+    result = detect_vp_flatline("rp_AYR_1.42", _preds([0.125] * 8), "rp_merged")
+    assert result is not None
+    assert result["flatline"] is True
+    assert result["unique_vp_count"] == 1
+    assert result["max_tie_group_size"] == 8
+    assert "RP_FEATURE_FLATLINE" in result["warning"]
+
+
+def test_flatline_majority_tied():
+    """7 of 9 runners tied → 77% tie group → flatline."""
+    result = detect_vp_flatline(
+        "rp_WAR_5.00",
+        _preds([0.1319, 0.1319, 0.1319, 0.1319, 0.1319, 0.1319, 0.1319, 0.0635, 0.0134]),
+        "rp_merged",
+    )
+    assert result is not None
+    assert result["flatline"] is True
+    assert result["max_tie_group_pct"] >= 0.60
+
+
+def test_flatline_silent_when_differentiated():
+    """5 fully distinct VP values → no flatline."""
+    result = detect_vp_flatline(
+        "rp_FFO_3.20",
+        _preds([0.5479, 0.2800, 0.1500, 0.0800, 0.0300]),
+        "rp_merged",
+    )
+    assert result is None
+
+
+def test_flatline_at_boundary():
+    """Exactly 60% tie group → flatline fires."""
+    vps = [0.25, 0.25, 0.25, 0.10, 0.08, 0.05]  # 3/6 = 50% — below threshold
+    result = detect_vp_flatline("rp_TEST", _preds(vps), "rp_merged")
+    assert result is None  # 50% < 60%
+
+    vps_boundary = [0.25, 0.25, 0.25, 0.25, 0.10, 0.05]  # 4/6 = 66.7% → fires
+    result2 = detect_vp_flatline("rp_TEST", _preds(vps_boundary), "rp_merged")
+    assert result2 is not None
+    assert result2["flatline"] is True
+
+
+def test_flatline_empty_predictions():
+    result = detect_vp_flatline("rp_TEST", [], "rp_merged")
+    assert result is None
+
+
+def test_flatline_single_runner():
+    """1-runner race has unique_count=1 but it's trivially uniform — still fires."""
+    result = detect_vp_flatline("rp_TEST", _preds([0.50]), "rp_merged")
+    assert result is not None
+
+
+# ── flatline_summary_for_run ──────────────────────────────────────────────────
+
+
+def test_flatline_summary_no_flatlines():
+    summary = flatline_summary_for_run([], total_races=32)
+    assert summary["flatline_count"] == 0
+    assert summary["flatline_pct"] == 0.0
+
+
+def test_flatline_summary_with_flatlines():
+    flatlines = [
+        detect_vp_flatline("rp_AYR_1.42", _preds([0.25] * 4), "rp_merged"),
+        detect_vp_flatline("rp_AYR_2.42", _preds([0.0833] * 12), "rp_merged"),
+        detect_vp_flatline(
+            "rp_WAR_5.00",
+            _preds([0.1319] * 7 + [0.0635, 0.0134]),
+            "rp_merged",
+        ),
+    ]
+    summary = flatline_summary_for_run(flatlines, total_races=32)
+    assert summary["flatline_count"] == 3
+    assert summary["fully_uniform_count"] == 2
+    assert summary["majority_tied_count"] == 1
+    assert summary["flatline_pct"] == round(3 / 32, 3)
+
+
+# ── Regression: 2026-05-20 VP uniformity pattern ─────────────────────────────
+
+
+def test_regression_ayr_142_was_uniform():
+    """
+    Before fix: AYR 1.42 had 4 runners all VP=0.25 (1/field_size).
+    After fix: if AYR merged JSON has no betting_forecast, odds=None → still flat.
+    This test documents the known pre-fix behaviour and confirms the detector fires.
+    """
+    # Simulate pre-fix VP=1/4 for 4 runners
+    pre_fix_preds = _preds([0.25, 0.25, 0.25, 0.25])
+    flatline = detect_vp_flatline("rp_AYR_20260520_1.42", pre_fix_preds, "rp_merged")
+    assert flatline is not None, "Regression: AYR 1.42 flatline should be detected"
+    assert flatline["unique_vp_count"] == 1
+    assert flatline["runner_count"] == 4
+
+
+def test_regression_ffo_320_was_differentiated():
+    """
+    FFO 3.20 (Kenobi) was already differentiated before fix.
+    After fix: betting_forecast makes it even more differentiated (more unique odds).
+    This is the reference race — must never regress to flatline.
+    """
+    # Simulate post-fix VP differentiation from betting forecast
+    # One Knight 4/6 → implied_prob=0.60, The Flaggy Shore 5/2 → 0.29, etc.
+    ffo_preds = _preds([0.5479, 0.3500, 0.2000, 0.0500, 0.0200])
+    flatline = detect_vp_flatline("rp_FFO_20260520_3.20", ffo_preds, "rp_merged")
+    assert flatline is None, "Regression: FFO 3.20 must NOT be a flatline"
+
+
+def test_regression_forecast_odds_differentiate_ffo():
+    """
+    Betting forecast parsing must produce distinct decimal odds for all 5 FFO 3.20 horses.
+    """
+    forecast = _parse_betting_forecast(_FFO_320_FORECAST)
+    odds_values = list(forecast.values())
+    assert len(odds_values) == 5
+    assert len(set(odds_values)) == 5, f"All 5 odds must be distinct: {odds_values}"
+    # Kenobi at 100/1 must be highest
+    assert forecast["kenobi"] == 101.0
+    # One Knight at 4/6 must be lowest (shortest price)
+    assert forecast["one knight"] < 2.0


### PR DESCRIPTION
Fixes the RP_MERGED VP flatline discovered in the 2026-05-20 300-runner review.

Changes:
- Parse RP betting_forecast into per-horse odds.
- Inject odds so normalizer sets best_odds_decimal.
- Wire RP TS into ts / ts_master.
- Attach pdf_intel before scoring.
- Add feature_audit.py with VP flatline detection.
- Wire RP_FEATURE_FLATLINE summary into run_prime_today timing/audit output.
- Add regression tests for the 2026-05-20 failure pattern.

Tests:
- python -m pytest tests/test_rp_feature_differentiation.py -v
- 32 passed

Required before merge:
- full CI
- replay 2026-05-20 RP_MERGED
- confirm flatline count drops materially
- confirm FFO 3.20 remains differentiated
- confirm no scoring weights, routing, or execution logic changed

Closes #85