### PR TITLE
Prime MOT: block false-green runs and restore pipeline truth

### DIFF
--- a/app/api/v1/predict.py
+++ b/app/api/v1/predict.py
@@ -3,7 +3,9 @@ VÉLØ Oracle - Production Prediction API
 Endpoints for real-time predictions
 """
 
+import hmac
 import logging
+import os
 from typing import Any
 
 from fastapi import APIRouter, Header, HTTPException
@@ -34,14 +36,14 @@ class PredictResponse(BaseModel):
 
 # API key validation
 def validate_api_key(x_api_key: str = Header(None)):
-    """Validate API key"""
+    """Validate the configured API key, failing closed."""
     if not x_api_key:
         raise HTTPException(status_code=401, detail="API key required")
 
-    # In production, check against database
-    valid_keys = ["test_key_123", "prod_key_456"]
-
-    if x_api_key not in valid_keys:
+    configured_key = os.getenv("API_KEY", "")
+    if not configured_key:
+        raise HTTPException(status_code=503, detail="API key not configured")
+    if not hmac.compare_digest(x_api_key, configured_key):
         raise HTTPException(status_code=403, detail="Invalid API key")
 
     return x_api_key
@@ -61,39 +63,6 @@ async def predict_full(request: PredictRequest, api_key: str = Header(None, alia
     # UMA QUARANTINED — Forensic Containment Active
     logger.critical("API ACCESS BLOCKED: /full endpoint attempted. UMA is QUARANTINED.")
     raise HTTPException(status_code=503, detail="UMA Brain is QUARANTINED for forensic containment. Use /quick or /ensemble.")
-
-    try:
-        # Load UMA (REMOVED - QUARANTINED)
-        # from app.engine.uma import UMA
-        uma.load_models()
-    except ImportError as e:
-        logger.error("Full prediction: model dependency missing — %s", e)
-        raise HTTPException(status_code=503, detail=f"Model dependency unavailable: {e}") from e
-    except Exception as e:
-        logger.error("Full prediction: model load failed — %s", e)
-        raise HTTPException(status_code=503, detail=f"Model load failed: {e}") from e
-
-    try:
-        # Generate prediction
-        prediction = uma.predict(
-            features=request.features, market_odds=request.market_odds, race_context={"race_id": request.race_id}
-        )
-
-        return PredictResponse(
-            race_id=request.race_id,
-            runner_id=request.runner_id,
-            probability=prediction.probability,
-            edge=prediction.edge,
-            confidence=prediction.confidence,
-            risk_band=prediction.risk_band,
-            signals=prediction.signals,
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Full prediction: inference failed — %s", e)
-        raise HTTPException(status_code=500, detail=f"Prediction inference error: {e}") from e
 
 
 @router.post("/quick", response_model=PredictResponse)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -9,6 +9,8 @@ import os
 from fastapi import HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from app.core.config import settings
+
 security = HTTPBearer(auto_error=False)
 
 

--- a/docs/VELO_CONNECTION_MAP.md
+++ b/docs/VELO_CONNECTION_MAP.md
@@ -1,0 +1,93 @@
+# VELO Connection Map
+
+Audit date: 2026-06-07
+
+## Connected Production-Intent Chain
+
+```text
+GitHub score-daily workflow / intended Railway cron
+  -> scripts/ops/run_prime_today.py
+  -> racecard loaders and source-truth gates
+  -> app/services/velo_prime_service.py::score_race_velo_prime
+  -> local verdict artifact
+  -> Supabase verdict persistence
+  -> scripts/ops/run_results_sigma.py
+  -> Sigma artifact / audit rows
+  -> nightly learning sidecars
+  -> scripts/ops/update_mission_control.py
+  -> Council / promotion decisions
+```
+
+The scripts and imports exist. The entire production chain is **not proven** because the
+live service is down, cron truth is absent, and the June 7 pipeline run record is absent.
+
+## Proven Call Chains
+
+| Chain | Proof | Status |
+|---|---|---|
+| `_open_pipeline_run` -> `pipeline_runs.insert` | direct code + passing persistence test after repair | CONNECTED |
+| daily run truth -> `build_mission_control` -> learning/promotion gates | direct code + two passing tests after repair | CONNECTED |
+| `app.main` -> Railway Nixpacks start command | `railway.toml` + import smoke | DEGRADED |
+| GitHub smoke -> production `/health` | workflow run + HTTP 502 | CONNECTED BUT FAILING |
+| June 7 verdicts -> Sigma -> learning sidecar | local artifacts | CONNECTED LOCALLY |
+
+## Disconnected / Orphaned Components
+
+| Component | Evidence | Status |
+|---|---|---|
+| `app/api/router.py` aggregate versioned router | no `app.main` include/reference found | ORPHANED |
+| `app/api/v1/predict.py` routes | only reachable through orphaned aggregate router | ORPHANED |
+| Feature/monitoring routers requiring `feast` | `app.main` catches missing dependency and continues | SILENTLY BYPASSED |
+| GitNexus current architecture graph | metadata points to old commit; refresh failed | UNPROVEN |
+| Phase 4 model-file assertions | required files absent in clean checkout | DISCONNECTED FROM REPRODUCIBLE BUILD |
+| 1.7M dataset-file assertion | file absent in clean checkout; live DB previously below target | UNPROVEN CLAIM |
+
+## Dead-End / Broken Data Paths
+
+1. **Verdicts -> no pipeline truth:** before repair, `_open_pipeline_run` generated an ID
+   but did not insert the database row.
+2. **Watchdog -> ignored by Mission Control:** watchdog detected missing pipeline truth,
+   but learning and promotion remained open.
+3. **Full-suite contract -> removed symbol:** HFS test imports
+   `compute_market_intelligence`, which no longer exists.
+4. **Health workflow -> unavailable service:** smoke reaches the configured production
+   URL and receives HTTP 502.
+
+## Duplicate Sources of Truth
+
+| Truth | Duplicates / conflict |
+|---|---|
+| Deployment status | runtime docs claim production; live health returns 502 |
+| Scheduler ownership | Railway cron documented; GitHub Actions also schedules scoring |
+| Daily readiness | Mission Control green conflicted with daily run truth failure |
+| Model availability | legacy tests/docs claim models that clean checkout lacks |
+| Dataset volume | 1.7M claim conflicts with absent reproducible dataset artifact |
+
+## GitNexus Findings
+
+GitNexus is an audit/development lens only. It does **not** need to be integrated into
+the VELO runtime.
+
+- Existing graph: 2,330 files, 43,702 nodes, 60,522 edges, 300 processes.
+- Indexed commit: `619f25a4416c8d659a60d5d6db262b626c3f57c7`.
+- Audited commit: `14ea7848827679a6687ebb0b70f155d07da85ad2`.
+- Refresh attempt failed in the GitNexus CLI.
+- Result: graph-derived connectivity for the audited code is **UNPROVEN**.
+
+Direct inspection takes precedence until GitNexus is refreshed.
+
+## Oracle of Odds Relationship
+
+Oracle of Odds is a separate clean challenger, not a Prime runtime dependency:
+
+```text
+Prime settled evidence exports
+  -> governed migration / training dataset
+  -> Oracle of Odds replayable pipeline
+  -> shadow evaluation
+  -> explicit evidence-gated promotion decision
+```
+
+Do not copy Prime's scheduler, deployment configuration, stale tests, or false-green
+gates into Oracle of Odds.
+

--- a/docs/VELO_MOT_AUDIT.md
+++ b/docs/VELO_MOT_AUDIT.md
@@ -1,0 +1,206 @@
+# VELO Oracle Prime MOT Audit
+
+Audit date: 2026-06-07  
+Audited clean commit: `14ea7848827679a6687ebb0b70f155d07da85ad2`  
+Audit branch: `codex/prime-mot-20260607`
+
+## Executive Summary
+
+**Verdict: NOT AUDIT-READY.**
+
+Prime can produce race verdicts, Sigma results, and learning artifacts, but its production
+service is unavailable and its operational truth chain was broken. On 2026-06-07,
+Mission Control reported both learning and promotion gates `OPEN` while the canonical
+daily run watchdog reported `VERDICTS_WITHOUT_PIPELINE_TRUTH`.
+
+This audit repaired the two code defects that caused that false-green state:
+
+1. `scripts/ops/run_prime_today.py::_open_pipeline_run` now actually inserts the
+   `pipeline_runs` truth row. The insert had been commented out.
+2. `scripts/ops/update_mission_control.py::build_mission_control` now blocks learning
+   and promotion unless daily run truth is `AUTOMATED_RUN_OK`.
+
+It also removed hardcoded API keys from the orphaned prediction router and repaired an
+undefined `settings` reference that was failing CI lint.
+
+The live deployment remains broken and unverified after repair because Railway returns
+HTTP `502` and Railway logs are inaccessible without authentication.
+
+## Current System Map
+
+```text
+RP PDFs / Racing API
+  -> collectors and RP parsers
+  -> current-card / merged-card builders
+  -> scripts/ops/run_prime_today.py
+  -> app/services/velo_prime_service.py
+  -> local verdict JSON + Supabase velo_verdicts
+  -> results parsers
+  -> scripts/ops/run_results_sigma.py
+  -> Sigma artifacts / sigma_audits
+  -> nightly learning and shadow evidence
+  -> Mission Control / Council gates
+
+FastAPI app.main
+  -> Railway Nixpacks start command
+  -> /health and /api/v1/build-fingerprint
+```
+
+## Real End-to-End Evidence
+
+The 2026-06-07 local artifacts prove a partial flow:
+
+| Stage | Evidence | Status |
+|---|---|---|
+| Scoring output | `data/velo_prime_verdicts_2026_06_07.json`, 30 verdicts | DEGRADED |
+| Result reconciliation | `data/sigma_results/sigma_results_2026_06_07.json`, 28 evaluated, 2 true non-runners | PASS |
+| Closure | Sigma unresolved rows = 0 | PASS |
+| Learning sidecar | `data/nightly_eod_learning_status_2026_06_07.json`, 30 updates, duplicates blocked | PASS |
+| Pipeline run truth | `data/velo_daily_run_truth_2026_06_07.md` says `VERDICTS_WITHOUT_PIPELINE_TRUTH` | FAIL |
+| Mission Control | Existing June 7 artifact opened both gates despite failed run truth | FAIL |
+| Production API | `/health` and `/api/v1/build-fingerprint` return HTTP 502 | FAIL |
+
+Verdicts existing does **not** prove an automated production run. The pipeline-run
+record, trigger source, deployed commit, cron execution, and service health are absent
+or failed.
+
+## Subsystem Status
+
+| Subsystem | Status | Evidence |
+|---|---|---|
+| Repository integrity | FAIL | Original worktree has 1,105 dirty paths; audit used a separate clean worktree |
+| Dependency reproducibility | DEGRADED | Production requirements include broad ranges; clean import warns `feast` missing |
+| Documented entrypoints | DEGRADED | All 21 documented scripts return exit 0 for `--help`; real external execution is unproven |
+| Ingestion | UNPROVEN | No clean-checkout end-to-end run against production sources/secrets |
+| Normalization | DEGRADED | Modules and entrypoints exist; full flow not proven in this audit |
+| Feature generation | FAIL | Full test collection breaks on stale `compute_market_intelligence` import |
+| Model plane | FAIL | Clean checkout lacks three model artifacts asserted by `tests/test_phase4_full.py` |
+| Daily scoring | DEGRADED | June 7 verdicts exist, but their pipeline truth is absent |
+| Persistence | DEGRADED | Commented-out pipeline-run insert repaired; live post-deploy proof still UNPROVEN |
+| Sigma / closure | DEGRADED | June 7 local Sigma is complete, but historical continuity and production trigger remain unproven |
+| Learning loop | DEGRADED | June 7 sidecar is idempotent; false-green admission gate repaired |
+| Mission Control / Council | DEGRADED | False-green fixed in code; council manual verification remains incomplete |
+| API | FAIL | Production endpoints return HTTP 502 |
+| Deployment / cron | FAIL | Repeated `smoke-prod` failures; Railway logs unavailable |
+| CI / tests | FAIL | CI fails; full pytest stops during collection; app lint has 49 errors |
+| Observability | DEGRADED | Watchdog caught missing truth, but Mission Control ignored it before repair |
+| GitNexus architecture evidence | UNPROVEN | Graph indexes commit `619f25a`, not audited commit; refresh command failed |
+| Oracle of Odds challenger | DEGRADED | 29 tests pass and smoke pipeline passes, but only sample-scale training is proven |
+
+## Ranked Failure Register
+
+### P0-01: Production service does not respond
+
+- Symptom: Railway `/health` and build fingerprint return HTTP 502.
+- Evidence: direct `curl`; repeated GitHub `smoke-prod` failures.
+- Impact: live API and health truth are unavailable.
+- Fix: inspect Railway deployment logs, repair startup, redeploy, require successful
+  health and fingerprint checks.
+- Status: **BLOCKED / UNPROVEN** because `railway logs` requires authentication.
+- Discovery: runtime test + GitHub Actions.
+
+### P0-02: Pipeline truth row was never inserted
+
+- Root cause: the database insert in `_open_pipeline_run` was commented out while the
+  function still returned a generated run ID.
+- Impact: verdicts could exist without a durable automated-run record.
+- Fix applied: restored `db.table("pipeline_runs").insert(row).execute()`.
+- Proof: `tests/test_pipeline_run_truth.py::test_open_pipeline_run_persists_truth_row`
+  now passes.
+- Discovery: runtime test + direct inspection.
+
+### P0-03: Mission Control could open learning and promotion on failed run truth
+
+- Symptom: June 7 Mission Control said `OPEN`; watchdog said
+  `VERDICTS_WITHOUT_PIPELINE_TRUTH`.
+- Root cause: Mission Control did not consume daily run truth.
+- Impact: unproven data could enter learning or promotion decisions.
+- Fix applied: both gates block unless run truth equals `AUTOMATED_RUN_OK`.
+- Proof: two new tests pass; synthetic missing-truth run returns both gates `BLOCKED`.
+- Discovery: artifact comparison + direct inspection + tests.
+
+### P1-01: Clean-checkout test suite cannot collect
+
+- Symptom: `pytest -q` stops importing `compute_market_intelligence`.
+- Root cause: `tests/test_hfs_feature_builder_v1.py` targets a removed service contract.
+- Impact: repository-wide regressions cannot be measured.
+- Exact remediation: reconcile the HFS test and service contract, then require full
+  pytest in CI.
+- Discovery: runtime test.
+
+### P1-02: Claimed model and 1.7M dataset artifacts are absent
+
+- Symptom: five Phase 4 tests fail in a clean checkout.
+- Missing: SQPE v14, Longshot v6, Overlay v5, and
+  `storage/velo-datasets/racing_full_1_7m.csv`.
+- Impact: historical claims and model reproducibility are not independently provable.
+- Exact remediation: publish immutable manifests/checksums and retrieval/build steps;
+  do not claim 1.7M until proven.
+- Discovery: runtime test + direct inspection.
+
+### P1-03: CI does not prove Prime
+
+- Symptom: CI test job only runs `workers/ingestion_spine`; current CI is failing lint.
+- Impact: green tests would not prove the production scoring/Sigma path.
+- Exact remediation: add Prime truth-gate tests, import smoke, full-suite collection,
+  and deployment smoke as required checks.
+- Discovery: workflow inspection + GitHub Actions.
+
+### P1-04: Prediction router carried hardcoded credentials
+
+- Scope: router is not mounted by `app.main`, so live exploitability is unproven.
+- Impact: future mounting would activate known credentials.
+- Fix applied: fail closed on configured `API_KEY` using constant-time comparison.
+- Discovery: call-chain inspection + direct inspection.
+
+### P2-01: GitNexus graph is stale
+
+- Evidence: `.gitnexus/meta.json` indexes `619f25a`; audited clean commit is `14ea784`.
+- Impact: disconnected/orphan claims cannot be trusted from the graph.
+- Remediation: repair GitNexus CLI, refresh graph, and rerun impact/disconnection checks.
+- Discovery: GitNexus metadata + failed refresh command.
+
+### P2-02: Duplicate deployment truth
+
+- Evidence: `railway.toml` selects Nixpacks and documents a server-side Railway cron,
+  while GitHub Actions also schedules scoring and Docker deployment material exists.
+- Impact: ownership and startup behavior can drift.
+- Remediation: declare one production start path and one scheduler of record.
+- Discovery: configuration inspection.
+
+## Fixes Applied
+
+- Restored durable `pipeline_runs` insertion.
+- Added Mission Control run-truth gate and regression tests.
+- Removed hardcoded prediction API credentials.
+- Fixed missing `settings` import used by CORS configuration.
+- Updated the legacy API-key test to use an environment-configured key.
+
+## Remaining Risks
+
+1. Production remains down.
+2. The full clean-checkout suite remains broken.
+3. Railway logs, cron truth, and deployed commit are UNPROVEN.
+4. Supabase post-repair persistence is UNPROVEN until deployed and queried.
+5. GitNexus findings are stale until the graph is refreshed.
+6. Original Prime worktree cleanliness is an audit blocker.
+7. Oracle of Odds is not yet trained on a production-sized settled-race corpus.
+
+## Evidence Appendix
+
+| Command | Result |
+|---|---|
+| `git rev-parse HEAD` | `14ea7848827679a6687ebb0b70f155d07da85ad2` |
+| Original `git status --porcelain` count | 1,105 dirty paths |
+| `curl .../health` | HTTP 502 |
+| `curl .../api/v1/build-fingerprint` | HTTP 502 |
+| `gh run list --limit 8` | latest `smoke-prod` FAIL, latest `ci` FAIL, `gx-validate` PASS |
+| `python -c "import app.main"` | PASS with missing-`feast` degradation warning |
+| `python -m pytest -q` | collection ERROR: removed `compute_market_intelligence` |
+| Focused truth/security pytest | 22 passed |
+| Legacy Phase 4 pytest | 5 failures: missing models/dataset |
+| `python -m ruff check app --statistics` | 49 errors |
+| Synthetic Mission Control missing truth | learning BLOCKED, promotion BLOCKED |
+| Oracle of Odds `pytest -q` | 29 passed |
+| Oracle of Odds smoke | PASS, 1 race, 2 verdicts, 2 closed |
+

--- a/docs/VELO_MOT_RUNBOOK.md
+++ b/docs/VELO_MOT_RUNBOOK.md
@@ -1,0 +1,81 @@
+# VELO MOT Runbook
+
+Run this before releases, audits, or investment reviews.
+
+## 1. Establish the Audited Commit
+
+```bash
+git status --short
+git rev-parse --abbrev-ref HEAD
+git rev-parse HEAD
+```
+
+Audit only a clean worktree. Record every exception.
+
+## 2. Prove Clean-Checkout Runtime
+
+```bash
+python -m pip install -r requirements_production.txt
+python -c "import app.main; print('import PASS')"
+python -m pytest -q --tb=short
+python -m ruff check app scripts/ops
+```
+
+Any collection error is a FAIL, not a skipped test.
+
+## 3. Prove Truth Gates
+
+```bash
+python -m pytest \
+  tests/test_pipeline_run_truth.py \
+  tests/test_mission_control_pipeline_truth_gate.py \
+  tests/test_p0_security.py -q
+```
+
+Required:
+
+- opening a scoring run persists a `pipeline_runs` row;
+- missing or non-automated run truth blocks learning and promotion;
+- authentication fails closed.
+
+## 4. Prove Production
+
+```bash
+curl -f https://velo-oracle-production.up.railway.app/health
+curl -f https://velo-oracle-production.up.railway.app/api/v1/build-fingerprint
+gh run list --limit 10
+railway logs
+```
+
+Record deployed commit, trigger source, start/finish times, races/runners processed,
+and the matching Supabase `pipeline_runs` row. If logs or secrets are unavailable,
+mark the result `UNPROVEN`.
+
+## 5. Prove Daily Closure
+
+For the target date, require:
+
+- verdict count reconciles to expected races;
+- Sigma coverage explains every verdict as evaluated, non-runner, or explicit failure;
+- unresolved count is zero or explained;
+- learning is idempotent;
+- Mission Control consumes the same daily run truth;
+- no promotion gate opens on missing/failed truth.
+
+## 6. Refresh Architecture Evidence
+
+Refresh GitNexus after the audited commit is checked out. Compare its entrypoints,
+orphans, and impact paths with direct `rg` inspection. GitNexus is not a runtime
+dependency.
+
+## Release Gate
+
+Release only when:
+
+1. production health and fingerprint pass;
+2. full pytest collects and passes;
+3. CI passes required Prime tests;
+4. the daily pipeline truth row exists and matches artifacts;
+5. Sigma and learning close without unexplained rows;
+6. Mission Control and Council do not contradict canonical truth.
+

--- a/scripts/ops/run_prime_today.py
+++ b/scripts/ops/run_prime_today.py
@@ -1329,11 +1329,10 @@ def _open_pipeline_run(db, date_str: str) -> PipelineRunOpenResult:
             "environment": env_str,
             "commit_sha": get_commit_sha(),
         }
-        # resp = db.table("pipeline_runs").insert(row).execute()
-        # if resp.data:
-        #    return PipelineRunOpenResult(run_id=resp.data[0]["id"])
-        # return PipelineRunOpenResult(error="pipeline_runs insert returned no data")
-        return PipelineRunOpenResult(run_id=row["id"])
+        resp = db.table("pipeline_runs").insert(row).execute()
+        if resp.data:
+            return PipelineRunOpenResult(run_id=resp.data[0]["id"])
+        return PipelineRunOpenResult(error="pipeline_runs insert returned no data")
     except Exception as e:
         detail = str(e)
         print(f"  [pipeline_runs] open failed: {detail}")

--- a/scripts/ops/update_mission_control.py
+++ b/scripts/ops/update_mission_control.py
@@ -20,13 +20,13 @@ import argparse
 import glob
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from app.core.mission_control_config import MC_CONFIG
+from app.core.mission_control_config import MC_CONFIG  # noqa: E402
 
 MC_DIR = ROOT / "data" / "mission_control"
 
@@ -85,7 +85,7 @@ def _detect_flatlines(rows: list[dict]) -> dict:
                     fully_uniform_set.add(rid)
 
     all_races: dict[str, set] = {}
-    for sha, races in by_run.items():
+    for _sha, races in by_run.items():
         for rid, vps in races.items():
             if rid not in all_races:
                 all_races[rid] = set()
@@ -135,7 +135,7 @@ def _gate_status(flatline_count: int, identity_failure_count: int, source_truth:
         learning_gate = MC_CONFIG.LEARNING_GATE_BLOCKED
         promotion_gate = MC_CONFIG.PROMOTION_GATE_BLOCKED
         reasons.append("GATE_SOURCE_CONTAMINATED")
-    
+
     if flatline_count > 0:
         learning_gate = MC_CONFIG.LEARNING_GATE_BLOCKED
         promotion_gate = MC_CONFIG.PROMOTION_GATE_BLOCKED
@@ -232,6 +232,36 @@ def _council_artifact_status(date_str: str) -> dict:
         "council_run": "PRESENT" if run_path.exists() else "MISSING",
         "council_packet": "PRESENT" if packet_path.exists() else "MISSING",
         "council_report": "PRESENT" if report_path.exists() else "MISSING",
+    }
+
+
+def _run_truth_status(date_str: str) -> dict:
+    date_und = date_str.replace("-", "_")
+    path = ROOT / "data" / f"velo_daily_run_truth_{date_und}.json"
+    if not path.exists():
+        return {
+            "status": "MISSING",
+            "path": None,
+            "alert_required": True,
+            "issues": ["DAILY_RUN_TRUTH_MISSING"],
+        }
+    try:
+        report = json.loads(path.read_text())
+    except Exception as exc:
+        return {
+            "status": "INVALID",
+            "path": str(path.relative_to(ROOT)),
+            "alert_required": True,
+            "issues": [f"DAILY_RUN_TRUTH_INVALID: {exc}"],
+        }
+    return {
+        "status": report.get("status", "UNKNOWN"),
+        "path": str(path.relative_to(ROOT)),
+        "alert_required": report.get("alert_required", True),
+        "issues": report.get("issues", []),
+        "cron_truth_status": report.get("cron_truth_status"),
+        "deploy_truth_status": report.get("deploy_truth_status"),
+        "pipeline_run_count": report.get("pipeline_run_count"),
     }
 
 
@@ -470,6 +500,7 @@ def build_mission_control(date_str: str) -> dict:
     gate_v2 = _gate_v2_status()
     sigma_artifact = _sigma_artifact_status(date_str)
     council_artifacts = _council_artifact_status(date_str)
+    run_truth = _run_truth_status(date_str)
     learning_admission = _learning_admission_status(date_str)
     race_shape = _race_shape_status()
     corpus_governance = _corpus_governance_status()
@@ -480,9 +511,14 @@ def build_mission_control(date_str: str) -> dict:
     rcg = gate_v2.get("runner_calibration_gate", {})
     dpg = gate_v2.get("decision_policy_gate", {})
 
+    if run_truth["status"] != "AUTOMATED_RUN_OK":
+        learning_gate = MC_CONFIG.LEARNING_GATE_BLOCKED
+        promotion_gate = MC_CONFIG.PROMOTION_GATE_BLOCKED
+        reason_codes.append(f"GATE_PIPELINE_TRUTH_{run_truth['status']}")
+
     mc = {
         "date": date_str,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
         "source_truth": source_truth,
         "run_ids_seen": run_ids,
         "flatline_count": flatline_data["flatline_count"],
@@ -496,6 +532,7 @@ def build_mission_control(date_str: str) -> dict:
         "promotion_gate_status": promotion_gate,
         "gate_reasons": reason_codes,
         "sigma_artifact": sigma_artifact,
+        "run_truth": run_truth,
         "council_artifact_visibility": council_artifacts,
         "runner_calibration_gate_status": rcg.get("status", "UNKNOWN"),
         "runner_calibration_gate_runners": rcg.get("runner_count", 0),

--- a/tests/test_mission_control_pipeline_truth_gate.py
+++ b/tests/test_mission_control_pipeline_truth_gate.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+from scripts.ops import update_mission_control
+
+
+def test_missing_run_truth_blocks_learning_and_promotion(monkeypatch, tmp_path):
+    monkeypatch.setattr(update_mission_control, "ROOT", tmp_path)
+
+    result = update_mission_control.build_mission_control("2026-06-07")
+
+    assert result["run_truth"]["status"] == "MISSING"
+    assert result["learning_gate_status"] == "BLOCKED"
+    assert result["promotion_gate_status"] == "BLOCKED"
+    assert "GATE_PIPELINE_TRUTH_MISSING" in result["gate_reasons"]
+
+
+def test_verdicts_without_pipeline_truth_blocks_false_green(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "velo_daily_run_truth_2026_06_07.json").write_text(
+        json.dumps(
+            {
+                "status": "VERDICTS_WITHOUT_PIPELINE_TRUTH",
+                "alert_required": True,
+                "issues": ["VERDICTS_WITHOUT_PIPELINE_TRUTH"],
+                "cron_truth_status": "FAIL_OR_UNPROVEN",
+            }
+        )
+    )
+    monkeypatch.setattr(update_mission_control, "ROOT", tmp_path)
+
+    result = update_mission_control.build_mission_control("2026-06-07")
+
+    assert result["run_truth"]["status"] == "VERDICTS_WITHOUT_PIPELINE_TRUTH"
+    assert result["learning_gate_status"] == "BLOCKED"
+    assert result["promotion_gate_status"] == "BLOCKED"

--- a/tests/test_phase4_full.py
+++ b/tests/test_phase4_full.py
@@ -219,17 +219,13 @@ class TestPhase4Full(unittest.TestCase):
     
     def test_24_api_key_validation(self):
         """Test API key validation"""
+        import os
+        from unittest.mock import patch
+
         from app.api.v1.predict import validate_api_key
-        from fastapi import HTTPException
-        
-        # Valid key should pass
-        try:
-            validate_api_key("test_key_123")
-            valid = True
-        except:
-            valid = False
-        
-        self.assertTrue(valid)
+
+        with patch.dict(os.environ, {"API_KEY": "configured-test-key"}, clear=False):
+            self.assertEqual(validate_api_key("configured-test-key"), "configured-test-key")
     
     def test_25_api_endpoints_exist(self):
         """Test all API endpoints exist"""


### PR DESCRIPTION
## Verdict\n\nPrime is **not audit-ready**. Production health returns HTTP 502, the full clean-checkout test suite cannot collect, and June 7 Mission Control opened learning/promotion while daily pipeline truth was absent.\n\n## Repairs\n\n- restore durable pipeline_runs insertion\n- block Mission Control learning/promotion unless run truth is AUTOMATED_RUN_OK\n- remove hardcoded prediction API keys\n- repair undefined CORS settings reference\n- add MOT audit, connection map, runbook, and regression tests\n\n## Proof\n\n- focused truth/security suite: 23 passed\n- targeted Ruff: passed\n- synthetic missing run truth: learning BLOCKED, promotion BLOCKED\n- full pytest: still fails during collection on stale compute_market_intelligence contract\n- live /health and build fingerprint: HTTP 502\n\nSee docs/VELO_MOT_AUDIT.md for the full evidence register.